### PR TITLE
[MOB-719] Apple Pay options

### DIFF
--- a/Airwallex/Airwallex.xcodeproj/project.pbxproj
+++ b/Airwallex/Airwallex.xcodeproj/project.pbxproj
@@ -34,6 +34,11 @@
 		3C455EB927E03B04009DB492 /* RLTMXProfiling.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3C455EB427E03B04009DB492 /* RLTMXProfiling.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3C455EBA27E03B04009DB492 /* RLTMXBehavioralBiometrics.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C455EB527E03B04009DB492 /* RLTMXBehavioralBiometrics.xcframework */; };
 		3C455EBB27E03B04009DB492 /* RLTMXBehavioralBiometrics.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3C455EB527E03B04009DB492 /* RLTMXBehavioralBiometrics.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		3C99E73C27E9A0730074156C /* AWXApplePayOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C99E73A27E9A0730074156C /* AWXApplePayOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3C99E73D27E9A0730074156C /* AWXApplePayOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C99E73B27E9A0730074156C /* AWXApplePayOptions.m */; };
+		3C99E73F27E9A3380074156C /* AWXDefaultProviderTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C99E73E27E9A3380074156C /* AWXDefaultProviderTest.m */; };
+		3C99E74527E9A51C0074156C /* AWXConstantsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C99E74427E9A51C0074156C /* AWXConstantsTest.m */; };
+		3C99E74727E9A6B70074156C /* AWXApplePayOptionsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C99E74627E9A6B70074156C /* AWXApplePayOptionsTest.m */; };
 		3C9ED16F27E97E800056615A /* Core.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 08D26F532404B6C3008E65D3 /* Core.bundle */; };
 		571D10862796DE4D005DE2CA /* WeChatPay.h in Headers */ = {isa = PBXBuildFile; fileRef = 57CEC82426E5FE2A00695740 /* WeChatPay.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		572D1BEE26DF4D06001EBDAA /* AWXSessionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 572D1BED26DF4D06001EBDAA /* AWXSessionTest.m */; };
@@ -266,6 +271,11 @@
 		3C455EB327E03B04009DB492 /* RLTMXProfilingConnections.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RLTMXProfilingConnections.xcframework; path = ../TrustDefender/RLTMXProfilingConnections.xcframework; sourceTree = "<group>"; };
 		3C455EB427E03B04009DB492 /* RLTMXProfiling.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RLTMXProfiling.xcframework; path = ../TrustDefender/RLTMXProfiling.xcframework; sourceTree = "<group>"; };
 		3C455EB527E03B04009DB492 /* RLTMXBehavioralBiometrics.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RLTMXBehavioralBiometrics.xcframework; path = ../TrustDefender/RLTMXBehavioralBiometrics.xcframework; sourceTree = "<group>"; };
+		3C99E73A27E9A0730074156C /* AWXApplePayOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AWXApplePayOptions.h; sourceTree = "<group>"; };
+		3C99E73B27E9A0730074156C /* AWXApplePayOptions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWXApplePayOptions.m; sourceTree = "<group>"; };
+		3C99E73E27E9A3380074156C /* AWXDefaultProviderTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWXDefaultProviderTest.m; sourceTree = "<group>"; };
+		3C99E74427E9A51C0074156C /* AWXConstantsTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWXConstantsTest.m; sourceTree = "<group>"; };
+		3C99E74627E9A6B70074156C /* AWXApplePayOptionsTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWXApplePayOptionsTest.m; sourceTree = "<group>"; };
 		3CF4FED827E95F1C00FB0CE4 /* Airwallex.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = Airwallex.xctestplan; sourceTree = "<group>"; };
 		570A139C25A82B270064B362 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../../README.md; sourceTree = "<group>"; };
 		570A139D25A82B280064B362 /* README_zh_CN.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = README_zh_CN.md; path = ../../README_zh_CN.md; sourceTree = "<group>"; };
@@ -575,6 +585,9 @@
 			children = (
 				0829FD4F24358E5600557DB2 /* XCTestCase+Utils.h */,
 				0829FD5024358E5600557DB2 /* XCTestCase+Utils.m */,
+				3C99E74627E9A6B70074156C /* AWXApplePayOptionsTest.m */,
+				3C99E74427E9A51C0074156C /* AWXConstantsTest.m */,
+				3C99E73E27E9A3380074156C /* AWXDefaultProviderTest.m */,
 				082442C62431BD5100D04A2C /* AWXTestUtils.h */,
 				082442C72431BD5100D04A2C /* AWXTestUtils.m */,
 				0829FD182432016900557DB2 /* Tools */,
@@ -701,6 +714,8 @@
 				5775CF0226E5DF4F00C6AFE3 /* AWXAddress.m */,
 				5775CEE726E5DF4E00C6AFE3 /* AWXAPIClient.h */,
 				5775CF0826E5DF4F00C6AFE3 /* AWXAPIClient.m */,
+				3C99E73A27E9A0730074156C /* AWXApplePayOptions.h */,
+				3C99E73B27E9A0730074156C /* AWXApplePayOptions.m */,
 				5775CED826E5DF4E00C6AFE3 /* AWXAPIResponse.h */,
 				5775CEF726E5DF4F00C6AFE3 /* AWXAPIResponse.m */,
 				5775CEE826E5DF4E00C6AFE3 /* AWXCard.h */,
@@ -822,6 +837,7 @@
 				5775CF4326E5DF5000C6AFE3 /* AWXViewController.h in Headers */,
 				5775CF2626E5DF4F00C6AFE3 /* AWXPaymentConsentRequest.h in Headers */,
 				5775CF4526E5DF5000C6AFE3 /* AWXPaymentConsent.h in Headers */,
+				3C99E73C27E9A0730074156C /* AWXApplePayOptions.h in Headers */,
 				5775CF2726E5DF4F00C6AFE3 /* AWXLogger.h in Headers */,
 				5775CF3326E5DF4F00C6AFE3 /* AWXPaymentMethodRequest.h in Headers */,
 				5775CF3626E5DF4F00C6AFE3 /* AWXForm.h in Headers */,
@@ -1236,6 +1252,7 @@
 				5775CF3426E5DF4F00C6AFE3 /* AWXCard.m in Sources */,
 				5775CF5826E5DF5000C6AFE3 /* AWXAPIClient.m in Sources */,
 				5775CF2526E5DF4F00C6AFE3 /* AWXPaymentConsentRequest.m in Sources */,
+				3C99E73D27E9A0730074156C /* AWXApplePayOptions.m in Sources */,
 				5775CF1A26E5DF4F00C6AFE3 /* AWXUIContext.m in Sources */,
 				5775CF1926E5DF4F00C6AFE3 /* AWXTheme.m in Sources */,
 				5775CF3526E5DF4F00C6AFE3 /* AWXTrackManager.m in Sources */,
@@ -1269,12 +1286,15 @@
 				0829FD1A2432019E00557DB2 /* AWXCardValidatorTest.m in Sources */,
 				0829FD4E243584E300557DB2 /* AWXTestAPIClient.m in Sources */,
 				0829FD022431D10800557DB2 /* AWXAddressTest.m in Sources */,
+				3C99E73F27E9A3380074156C /* AWXDefaultProviderTest.m in Sources */,
 				082442CC2431C00E00D04A2C /* AWXCardTest.m in Sources */,
 				572D1BEE26DF4D06001EBDAA /* AWXSessionTest.m in Sources */,
 				0829FD082431D25800557DB2 /* AWXBillingTest.m in Sources */,
+				3C99E74727E9A6B70074156C /* AWXApplePayOptionsTest.m in Sources */,
 				0829FD132431E11E00557DB2 /* AWXPaymentMethodFunctionalTest.m in Sources */,
 				0829FD5124358E5600557DB2 /* XCTestCase+Utils.m in Sources */,
 				0829FD152431F13A00557DB2 /* AWXPaymentIntentFunctionalTest.m in Sources */,
+				3C99E74527E9A51C0074156C /* AWXConstantsTest.m in Sources */,
 				082442C82431BD5100D04A2C /* AWXTestUtils.m in Sources */,
 				0829FD0E2431D3C200557DB2 /* AWXPaymentMethodTest.m in Sources */,
 			);

--- a/Airwallex/Core/Sources/AWXApplePayOptions.h
+++ b/Airwallex/Core/Sources/AWXApplePayOptions.h
@@ -1,0 +1,70 @@
+//
+//  AWXApplePayOptions.h
+//  Core
+//
+//  Created by Jin Wang on 22/3/2022.
+//  Copyright © 2022 Airwallex. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <PassKit/PassKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface AWXApplePayOptions : NSObject
+
+/**
+ Apple Pay merchant identifier.
+ */
+@property (nonatomic, copy) NSString *merchantIdentifier;
+
+/**
+ Apple Pay merchant capabilities. Default value includes 3DS, EMV, Credit and Debit.
+ */
+@property (nonatomic, assign) PKMerchantCapability merchantCapabilities;
+
+/**
+ How the item are to be shipped. Default value is PKShippingTypeShipping.
+ */
+@property (nonatomic, assign) PKShippingType shippingType;
+
+/**
+ The billing information that you require from the user in order to process the transaction. Default value is empty set.
+ */
+@property (nonatomic, strong) NSSet <PKContactField> *requiredBillingContactFields;
+
+/**
+ The shipping information that you require from the user in order to fulfill the order. Default value is empty set.
+ */
+@property (nonatomic, strong) NSSet <PKContactField> *requiredShippingContactFields;
+
+/**
+ Description of the total price. Default value is nil.
+ */
+@property (nonatomic, copy, nullable) NSString *totalPriceLabel;
+
+/**
+ A list of ISO 3166 country codes for limiting payments to cards from specific countries. Default value is null, meaning all countries are allowed.
+ */
+@property (nonatomic, copy, nullable) NSSet <NSString *> *supportedCountries;
+
+/**
+ A set of shipping method objects that describe the available shipping methods. Default value is nil.
+ */
+@property (nonatomic, strong, nullable) NSArray <PKShippingMethod *> *shippingMethods;
+
+/**
+ Shipping contact information for the user. Default value is nil.
+ */
+@property (nonatomic, strong, nullable) PKContact *shippingContact;
+
+/**
+ Billing contact information for the user. Default value is nil.
+ */
+@property (nonatomic, strong, nullable) PKContact *billingContact;
+
+- (instancetype)initWithMerchantIdentifier:(NSString *)merchantIdentifier;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Airwallex/Core/Sources/AWXApplePayOptions.m
+++ b/Airwallex/Core/Sources/AWXApplePayOptions.m
@@ -1,0 +1,27 @@
+//
+//  AWXApplePayOptions.m
+//  Core
+//
+//  Created by Jin Wang on 22/3/2022.
+//  Copyright © 2022 Airwallex. All rights reserved.
+//
+
+#import "AWXApplePayOptions.h"
+#import "AWXConstants.h"
+
+@implementation AWXApplePayOptions
+
+- (instancetype)initWithMerchantIdentifier:(NSString *)merchantIdentifier
+{
+    self = [super init];
+    if (self) {
+        _merchantIdentifier = merchantIdentifier;
+        _merchantCapabilities = PKMerchantCapability3DS | PKMerchantCapabilityEMV | PKMerchantCapabilityDebit | PKMerchantCapabilityCredit;
+        _shippingType = PKShippingTypeShipping;
+        _requiredBillingContactFields = [NSSet new];
+        _requiredShippingContactFields = [NSSet new];
+    }
+    return self;
+}
+
+@end

--- a/Airwallex/Core/Sources/AWXConstants.h
+++ b/Airwallex/Core/Sources/AWXConstants.h
@@ -8,6 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+#import <PassKit/PassKit.h>
 
 @class AWXPaymentMethodType, AWXConfirmPaymentNextAction;
 
@@ -84,6 +85,9 @@ FOUNDATION_EXPORT NSString *const AWXThreeDSWaitingUserInfoInput;
 FOUNDATION_EXPORT NSString *const AWXThreeDSValidate;
 FOUNDATION_EXPORT NSString *const AWXThreeDSContinue;
 FOUNDATION_EXPORT NSString *const AWXDCC;
+
+FOUNDATION_EXPORT NSString *const AWXApplePayKey;
+FOUNDATION_EXPORT NSArray <PKPaymentNetwork> *AWXApplePaySupportedNetworks(void);
 
 FOUNDATION_EXPORT NSString * FormatAirwallexSDKMode(AirwallexSDKMode mode);
 FOUNDATION_EXPORT NSString * FormatNextTriggerByType(AirwallexNextTriggerByType type);

--- a/Airwallex/Core/Sources/AWXConstants.m
+++ b/Airwallex/Core/Sources/AWXConstants.m
@@ -33,6 +33,22 @@ NSString *const AWXThreeDSValidate = @"3dsValidate";
 NSString *const AWXThreeDSContinue = @"3ds_continue";
 NSString *const AWXDCC = @"dcc";
 
+NSString *const AWXApplePayKey = @"applepay";
+
+NSArray <PKPaymentNetwork> * AWXApplePaySupportedNetworks(void)
+{
+    NSArray <PKPaymentNetwork> *shared = @[
+        PKPaymentNetworkVisa,
+        PKPaymentNetworkMasterCard,
+        PKPaymentNetworkChinaUnionPay
+    ];
+    if (@available(iOS 12.0, *)) {
+        return [shared arrayByAddingObject:PKPaymentNetworkMaestro];
+    } else {
+        return shared;
+    }
+}
+
 NSString * FormatAirwallexSDKMode(AirwallexSDKMode mode)
 {
     switch (mode) {

--- a/Airwallex/Core/Sources/AWXDefaultProvider.h
+++ b/Airwallex/Core/Sources/AWXDefaultProvider.h
@@ -97,6 +97,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, readonly, nullable) AWXPaymentMethod *paymentMethod;
 
+/**
+ Indicating whether the provider can handle a particular session. Default implementation returns YES. Subclasses can override to
+ do additional checks.
+ */
++ (BOOL)canHandleSession:(AWXSession *)session;
+
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)initWithDelegate:(id <AWXProviderDelegate>)delegate session:(AWXSession *)session;

--- a/Airwallex/Core/Sources/AWXDefaultProvider.m
+++ b/Airwallex/Core/Sources/AWXDefaultProvider.m
@@ -30,6 +30,11 @@
 
 @implementation AWXDefaultProvider
 
++ (BOOL)canHandleSession:(AWXSession *)session
+{
+    return YES;
+}
+
 - (instancetype)initWithDelegate:(id <AWXProviderDelegate>)delegate session:(AWXSession *)session
 {
     return [self initWithDelegate:delegate session:session paymentMethod:nil];

--- a/Airwallex/Core/Sources/AWXPaymentMethod.h
+++ b/Airwallex/Core/Sources/AWXPaymentMethod.h
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface AWXPaymentMethod : NSObject <AWXJSONEncodable, AWXJSONDecodable>
 
 /**
- Type of the payment method. One of card, wechatpay.
+ Type of the payment method. One of card, wechatpay, applepay.
  */
 @property (nonatomic, copy) NSString *type;
 
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) AWXCard *card;
 
 /**
- Additional params  for wechat or redirect type.
+ Additional params  for wechat, redirect or applepay type.
  */
 @property (nonatomic, strong, nullable) NSDictionary *additionalParams;
 

--- a/Airwallex/Core/Sources/AWXSession.h
+++ b/Airwallex/Core/Sources/AWXSession.h
@@ -10,6 +10,7 @@
 #import "AWXPlaceDetails.h"
 #import "AWXPaymentIntent.h"
 #import "AWXConstants.h"
+#import "AWXApplePayOptions.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -32,6 +33,11 @@ NS_ASSUME_NONNULL_BEGIN
  The billing address.
  */
 @property (nonatomic, strong, nullable) AWXPlaceDetails *billing;
+
+/**
+ Apple Pay options.
+ */
+@property (nonatomic, strong, nullable) AWXApplePayOptions *applePayOptions;
 
 /**
  Return URL.

--- a/Airwallex/Core/Sources/AWXUtils.m
+++ b/Airwallex/Core/Sources/AWXUtils.m
@@ -36,7 +36,7 @@ static NSString * const kSDKSuiteName = @"com.airwallex.sdk";
 
 + (NSBundle *)resourceBundle
 {
-    return [NSBundle bundleWithPath:[self.sdkBundle pathForResource:@"AirwallexSDK" ofType:@"bundle"]];
+    return [NSBundle bundleWithPath:[self.sdkBundle pathForResource:@"Core" ofType:@"bundle"]];
 }
 
 @end

--- a/Airwallex/Core/Sources/Core.h
+++ b/Airwallex/Core/Sources/Core.h
@@ -17,6 +17,7 @@ FOUNDATION_EXPORT const unsigned char CoreVersionString[];
 
 #import "AWXAddress.h"
 #import "AWXAPIClient.h"
+#import "AWXApplePayOptions.h"
 #import "AWXCard.h"
 #import "AWXCodable.h"
 #import "AWXConstants.h"

--- a/Airwallex/CoreTests/AWXApplePayOptionsTest.m
+++ b/Airwallex/CoreTests/AWXApplePayOptionsTest.m
@@ -1,0 +1,33 @@
+//
+//  AWXApplePayOptionsTest.m
+//  CoreTests
+//
+//  Created by Jin Wang on 22/3/2022.
+//  Copyright © 2022 Airwallex. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "AWXApplePayOptions.h"
+
+@interface AWXApplePayOptionsTest : XCTestCase
+
+@end
+
+@implementation AWXApplePayOptionsTest
+
+- (void)testInitWithMerchantIdentifier {
+    NSString *identifier = @"merchantIdentifier";
+    AWXApplePayOptions *options = [[AWXApplePayOptions alloc] initWithMerchantIdentifier:identifier];
+    
+    XCTAssertEqualObjects(options.merchantIdentifier, identifier);
+    XCTAssertEqual(options.shippingType, PKShippingTypeShipping);
+    XCTAssertEqualObjects(options.requiredBillingContactFields, [NSSet new]);
+    XCTAssertEqualObjects(options.requiredShippingContactFields, [NSSet new]);
+    XCTAssertNil(options.totalPriceLabel);
+    XCTAssertNil(options.supportedCountries);
+    XCTAssertNil(options.shippingMethods);
+    XCTAssertNil(options.shippingContact);
+    XCTAssertNil(options.billingContact);
+}
+
+@end

--- a/Airwallex/CoreTests/AWXConstantsTest.m
+++ b/Airwallex/CoreTests/AWXConstantsTest.m
@@ -1,0 +1,31 @@
+//
+//  AWXConstantsTest.m
+//  CoreTests
+//
+//  Created by Jin Wang on 22/3/2022.
+//  Copyright © 2022 Airwallex. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "AWXConstants.h"
+
+@interface AWXConstantsTest : XCTestCase
+
+@end
+
+@implementation AWXConstantsTest
+
+- (void)testApplePayKey {
+    XCTAssertEqualObjects(AWXApplePayKey, @"applepay");
+}
+
+- (void)testApplePaySupportedNetworks {
+    XCTAssertTrue([AWXApplePaySupportedNetworks() containsObject:PKPaymentNetworkVisa]);
+    XCTAssertTrue([AWXApplePaySupportedNetworks() containsObject:PKPaymentNetworkMasterCard]);
+    XCTAssertTrue([AWXApplePaySupportedNetworks() containsObject:PKPaymentNetworkChinaUnionPay]);
+    if (@available(iOS 12.0, *)) {
+        XCTAssertTrue([AWXApplePaySupportedNetworks() containsObject:PKPaymentNetworkMaestro]);
+    }
+}
+
+@end

--- a/Airwallex/CoreTests/AWXDefaultProviderTest.m
+++ b/Airwallex/CoreTests/AWXDefaultProviderTest.m
@@ -1,0 +1,24 @@
+//
+//  AWXDefaultProviderTest.m
+//  CoreTests
+//
+//  Created by Jin Wang on 22/3/2022.
+//  Copyright © 2022 Airwallex. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "AWXDefaultProvider.h"
+#import "AWXSession.h"
+
+@interface AWXDefaultProviderTest : XCTestCase
+
+@end
+
+@implementation AWXDefaultProviderTest
+
+- (void)testCanHandleSessionDefaultImplementation {
+    AWXSession *session = [AWXSession new];
+    XCTAssertTrue([AWXDefaultProvider canHandleSession:session]);
+}
+
+@end


### PR DESCRIPTION
This PR
- exposes a new `ApplePayOptions` class on the `AWXSession` for merchants to specify the necessary parameters in order for Apple Pay to work.
- added a new static method `canHandleSession` to `AWXDefaultProvider` so that subclasses can optionally check if a particular session is supported. This will help avoid showing Apple Pay button in the payment list if Apple Pay is not available on this device. The actual implementation will be introduced in the next PR.

The options is marked as optional, meaning that if the merchant doesn't support Apple Pay or the merchant hasn't integrated the upcoming Apple Pay module, then there's no need to specify the options.

The properties and the default values of the options should match the ones defined in the web implementation. https://gitlab.awx.im/acquiring/airwallex-payment-elements/-/blob/master/types/element.d.ts#L560