### PR TITLE
[MOB-719] feat: toggle apple pay button visibility 

### DIFF
--- a/Airwallex.podspec
+++ b/Airwallex.podspec
@@ -34,4 +34,10 @@ Pod::Spec.new do |s|
     plugin.dependency 'Airwallex/Core'
     plugin.source_files = 'Airwallex/Redirect/*.{h,m}'
   end
+  
+  s.subspec 'ApplePay' do |plugin|
+    plugin.dependency 'Airwallex/Core'
+    plugin.source_files = 'Airwallex/ApplePay/**/*.{h,m}'
+    plugin.public_header_files = 'Airwallex/ApplePay/*.h'
+  end
 end

--- a/Airwallex/Airwallex.xcodeproj/project.pbxproj
+++ b/Airwallex/Airwallex.xcodeproj/project.pbxproj
@@ -34,11 +34,17 @@
 		3C455EB927E03B04009DB492 /* RLTMXProfiling.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3C455EB427E03B04009DB492 /* RLTMXProfiling.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3C455EBA27E03B04009DB492 /* RLTMXBehavioralBiometrics.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C455EB527E03B04009DB492 /* RLTMXBehavioralBiometrics.xcframework */; };
 		3C455EBB27E03B04009DB492 /* RLTMXBehavioralBiometrics.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3C455EB527E03B04009DB492 /* RLTMXBehavioralBiometrics.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		3C5A37D627EAFD9F00CFC2EF /* AWXApplePayProviderTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C5A37D527EAFD9F00CFC2EF /* AWXApplePayProviderTest.m */; };
 		3C99E73C27E9A0730074156C /* AWXApplePayOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C99E73A27E9A0730074156C /* AWXApplePayOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3C99E73D27E9A0730074156C /* AWXApplePayOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C99E73B27E9A0730074156C /* AWXApplePayOptions.m */; };
 		3C99E73F27E9A3380074156C /* AWXDefaultProviderTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C99E73E27E9A3380074156C /* AWXDefaultProviderTest.m */; };
 		3C99E74527E9A51C0074156C /* AWXConstantsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C99E74427E9A51C0074156C /* AWXConstantsTest.m */; };
 		3C99E74727E9A6B70074156C /* AWXApplePayOptionsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C99E74627E9A6B70074156C /* AWXApplePayOptionsTest.m */; };
+		3C99E78F27EAF1A20074156C /* ApplePay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C99E78727EAF1A10074156C /* ApplePay.framework */; };
+		3C99E79527EAF1A20074156C /* ApplePay.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C99E78927EAF1A20074156C /* ApplePay.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3C99E7A427EAF2840074156C /* AWXApplePayProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C99E7A227EAF2840074156C /* AWXApplePayProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3C99E7A527EAF2840074156C /* AWXApplePayProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C99E7A327EAF2840074156C /* AWXApplePayProvider.m */; };
+		3C99E7A627EAF4890074156C /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 085BD3C823CC62B4002E8F27 /* Core.framework */; platformFilter = ios; };
 		3C9ED16F27E97E800056615A /* Core.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 08D26F532404B6C3008E65D3 /* Core.bundle */; };
 		571D10862796DE4D005DE2CA /* WeChatPay.h in Headers */ = {isa = PBXBuildFile; fileRef = 57CEC82426E5FE2A00695740 /* WeChatPay.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		572D1BEE26DF4D06001EBDAA /* AWXSessionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 572D1BED26DF4D06001EBDAA /* AWXSessionTest.m */; };
@@ -157,6 +163,7 @@
 		57D4A4502785AF4500487E1C /* AWX3DSViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 57D4A44E2785AF4500487E1C /* AWX3DSViewController.m */; };
 		57E73719272AC043009905DC /* AWXSchemaProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 57E73717272AC043009905DC /* AWXSchemaProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		57E7371A272AC043009905DC /* AWXSchemaProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 57E73718272AC043009905DC /* AWXSchemaProvider.m */; };
+		84ABDD9C25F82D99D0AD3C89 /* libPods-ApplePayTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 899E89AF61B2429D20A09351 /* libPods-ApplePayTests.a */; };
 		FB3A40A35045223F14992EB6 /* libPods-WeChatPay.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DB09DF046200297622B4A4A7 /* libPods-WeChatPay.a */; };
 /* End PBXBuildFile section */
 
@@ -169,6 +176,27 @@
 			remoteInfo = Airwallex;
 		};
 		3C2B64A727E98863002FAF3E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 085BD3BF23CC62B4002E8F27 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3C2B648D27E98858002FAF3E;
+			remoteInfo = TestHost;
+		};
+		3C99E79027EAF1A20074156C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 085BD3BF23CC62B4002E8F27 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3C99E78627EAF1A10074156C;
+			remoteInfo = ApplePay;
+		};
+		3C99E7A827EAF4890074156C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 085BD3BF23CC62B4002E8F27 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 085BD3C723CC62B4002E8F27;
+			remoteInfo = Core;
+		};
+		3C99E7AB27EAF4B90074156C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 085BD3BF23CC62B4002E8F27 /* Project object */;
 			proxyType = 1;
@@ -271,11 +299,17 @@
 		3C455EB327E03B04009DB492 /* RLTMXProfilingConnections.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RLTMXProfilingConnections.xcframework; path = ../TrustDefender/RLTMXProfilingConnections.xcframework; sourceTree = "<group>"; };
 		3C455EB427E03B04009DB492 /* RLTMXProfiling.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RLTMXProfiling.xcframework; path = ../TrustDefender/RLTMXProfiling.xcframework; sourceTree = "<group>"; };
 		3C455EB527E03B04009DB492 /* RLTMXBehavioralBiometrics.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RLTMXBehavioralBiometrics.xcframework; path = ../TrustDefender/RLTMXBehavioralBiometrics.xcframework; sourceTree = "<group>"; };
+		3C5A37D527EAFD9F00CFC2EF /* AWXApplePayProviderTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWXApplePayProviderTest.m; sourceTree = "<group>"; };
 		3C99E73A27E9A0730074156C /* AWXApplePayOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AWXApplePayOptions.h; sourceTree = "<group>"; };
 		3C99E73B27E9A0730074156C /* AWXApplePayOptions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWXApplePayOptions.m; sourceTree = "<group>"; };
 		3C99E73E27E9A3380074156C /* AWXDefaultProviderTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWXDefaultProviderTest.m; sourceTree = "<group>"; };
 		3C99E74427E9A51C0074156C /* AWXConstantsTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWXConstantsTest.m; sourceTree = "<group>"; };
 		3C99E74627E9A6B70074156C /* AWXApplePayOptionsTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWXApplePayOptionsTest.m; sourceTree = "<group>"; };
+		3C99E78727EAF1A10074156C /* ApplePay.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ApplePay.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3C99E78927EAF1A20074156C /* ApplePay.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ApplePay.h; sourceTree = "<group>"; };
+		3C99E78E27EAF1A20074156C /* ApplePayTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ApplePayTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		3C99E7A227EAF2840074156C /* AWXApplePayProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AWXApplePayProvider.h; sourceTree = "<group>"; };
+		3C99E7A327EAF2840074156C /* AWXApplePayProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWXApplePayProvider.m; sourceTree = "<group>"; };
 		3CF4FED827E95F1C00FB0CE4 /* Airwallex.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = Airwallex.xctestplan; sourceTree = "<group>"; };
 		570A139C25A82B270064B362 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../../README.md; sourceTree = "<group>"; };
 		570A139D25A82B280064B362 /* README_zh_CN.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = README_zh_CN.md; path = ../../README_zh_CN.md; sourceTree = "<group>"; };
@@ -405,7 +439,10 @@
 		57D4A44E2785AF4500487E1C /* AWX3DSViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWX3DSViewController.m; sourceTree = "<group>"; };
 		57E73717272AC043009905DC /* AWXSchemaProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AWXSchemaProvider.h; sourceTree = "<group>"; };
 		57E73718272AC043009905DC /* AWXSchemaProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWXSchemaProvider.m; sourceTree = "<group>"; };
+		79CC91FEFC20844097DA8051 /* Pods-ApplePayTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ApplePayTests.debug.xcconfig"; path = "Target Support Files/Pods-ApplePayTests/Pods-ApplePayTests.debug.xcconfig"; sourceTree = "<group>"; };
 		8096B137EDD3F3FFD5786CEB /* Pods-WeChatPay.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WeChatPay.debug.xcconfig"; path = "Target Support Files/Pods-WeChatPay/Pods-WeChatPay.debug.xcconfig"; sourceTree = "<group>"; };
+		899E89AF61B2429D20A09351 /* libPods-ApplePayTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ApplePayTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		BD25D2EFD8E73A8E45ECDB24 /* Pods-ApplePayTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ApplePayTests.release.xcconfig"; path = "Target Support Files/Pods-ApplePayTests/Pods-ApplePayTests.release.xcconfig"; sourceTree = "<group>"; };
 		DB09DF046200297622B4A4A7 /* libPods-WeChatPay.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-WeChatPay.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FBC8B399FD2DBF11F6F2E2CF /* Pods-WeChatPay.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WeChatPay.release.xcconfig"; path = "Target Support Files/Pods-WeChatPay/Pods-WeChatPay.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -430,6 +467,23 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3C99E78427EAF1A10074156C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3C99E7A627EAF4890074156C /* Core.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3C99E78B27EAF1A20074156C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3C99E78F27EAF1A20074156C /* ApplePay.framework in Frameworks */,
+				84ABDD9C25F82D99D0AD3C89 /* libPods-ApplePayTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -543,6 +597,8 @@
 				5775CEAC26E5DF3300C6AFE3 /* Redirect */,
 				5775CEB726E5DF3300C6AFE3 /* RedirectTests */,
 				3C2B648F27E98858002FAF3E /* TestHost */,
+				3C99E78827EAF1A20074156C /* ApplePay */,
+				3C99E79227EAF1A20074156C /* ApplePayTests */,
 				085BD3C923CC62B4002E8F27 /* Products */,
 				B6CB5D85D9AF529D3A580470 /* Pods */,
 				9261DD5DE5B6EE3DE55C5588 /* Frameworks */,
@@ -561,6 +617,8 @@
 				5775CEAB26E5DF3300C6AFE3 /* Redirect.framework */,
 				5775CEB326E5DF3300C6AFE3 /* RedirectTests.xctest */,
 				3C2B648E27E98858002FAF3E /* TestHost.app */,
+				3C99E78727EAF1A10074156C /* ApplePay.framework */,
+				3C99E78E27EAF1A20074156C /* ApplePayTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -621,6 +679,24 @@
 				3C2B64A227E98859002FAF3E /* main.m */,
 			);
 			path = TestHost;
+			sourceTree = "<group>";
+		};
+		3C99E78827EAF1A20074156C /* ApplePay */ = {
+			isa = PBXGroup;
+			children = (
+				3C99E78927EAF1A20074156C /* ApplePay.h */,
+				3C99E7A227EAF2840074156C /* AWXApplePayProvider.h */,
+				3C99E7A327EAF2840074156C /* AWXApplePayProvider.m */,
+			);
+			path = ApplePay;
+			sourceTree = "<group>";
+		};
+		3C99E79227EAF1A20074156C /* ApplePayTests */ = {
+			isa = PBXGroup;
+			children = (
+				3C5A37D527EAFD9F00CFC2EF /* AWXApplePayProviderTest.m */,
+			);
+			path = ApplePayTests;
 			sourceTree = "<group>";
 		};
 		5775CE6026E5D86100C6AFE3 /* WeChatPay */ = {
@@ -797,6 +873,7 @@
 				3C455EB427E03B04009DB492 /* RLTMXProfiling.xcframework */,
 				3C455EB327E03B04009DB492 /* RLTMXProfilingConnections.xcframework */,
 				DB09DF046200297622B4A4A7 /* libPods-WeChatPay.a */,
+				899E89AF61B2429D20A09351 /* libPods-ApplePayTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -806,6 +883,8 @@
 			children = (
 				8096B137EDD3F3FFD5786CEB /* Pods-WeChatPay.debug.xcconfig */,
 				FBC8B399FD2DBF11F6F2E2CF /* Pods-WeChatPay.release.xcconfig */,
+				79CC91FEFC20844097DA8051 /* Pods-ApplePayTests.debug.xcconfig */,
+				BD25D2EFD8E73A8E45ECDB24 /* Pods-ApplePayTests.release.xcconfig */,
 			);
 			name = Pods;
 			path = ../Pods;
@@ -857,6 +936,15 @@
 				5775CF5D26E5DF5000C6AFE3 /* AWXPaymentMethodOptions.h in Headers */,
 				5775CF3126E5DF4F00C6AFE3 /* AWXPaymentMethodCell.h in Headers */,
 				5775CF5A26E5DF5000C6AFE3 /* AWXTrackManager.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3C99E78227EAF1A10074156C /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3C99E7A427EAF2840074156C /* AWXApplePayProvider.h in Headers */,
+				3C99E79527EAF1A20074156C /* ApplePay.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -955,6 +1043,45 @@
 			productName = TestHost;
 			productReference = 3C2B648E27E98858002FAF3E /* TestHost.app */;
 			productType = "com.apple.product-type.application";
+		};
+		3C99E78627EAF1A10074156C /* ApplePay */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3C99E79A27EAF1A20074156C /* Build configuration list for PBXNativeTarget "ApplePay" */;
+			buildPhases = (
+				3C99E78227EAF1A10074156C /* Headers */,
+				3C99E78327EAF1A10074156C /* Sources */,
+				3C99E78427EAF1A10074156C /* Frameworks */,
+				3C99E78527EAF1A10074156C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3C99E7A927EAF4890074156C /* PBXTargetDependency */,
+			);
+			name = ApplePay;
+			productName = ApplePay;
+			productReference = 3C99E78727EAF1A10074156C /* ApplePay.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		3C99E78D27EAF1A20074156C /* ApplePayTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3C99E79B27EAF1A20074156C /* Build configuration list for PBXNativeTarget "ApplePayTests" */;
+			buildPhases = (
+				525628A94F7646EA0BA48A10 /* [CP] Check Pods Manifest.lock */,
+				3C99E78A27EAF1A20074156C /* Sources */,
+				3C99E78B27EAF1A20074156C /* Frameworks */,
+				3C99E78C27EAF1A20074156C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3C99E79127EAF1A20074156C /* PBXTargetDependency */,
+				3C99E7AC27EAF4B90074156C /* PBXTargetDependency */,
+			);
+			name = ApplePayTests;
+			productName = ApplePayTests;
+			productReference = 3C99E78E27EAF1A20074156C /* ApplePayTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		5775CE5E26E5D86100C6AFE3 /* WeChatPay */ = {
 			isa = PBXNativeTarget;
@@ -1089,6 +1216,13 @@
 					3C2B648D27E98858002FAF3E = {
 						CreatedOnToolsVersion = 13.3;
 					};
+					3C99E78627EAF1A10074156C = {
+						CreatedOnToolsVersion = 13.3;
+					};
+					3C99E78D27EAF1A20074156C = {
+						CreatedOnToolsVersion = 13.3;
+						TestTargetID = 3C2B648D27E98858002FAF3E;
+					};
 					5775CE5E26E5D86100C6AFE3 = {
 						CreatedOnToolsVersion = 12.5.1;
 					};
@@ -1131,6 +1265,8 @@
 				5775CEAA26E5DF3300C6AFE3 /* Redirect */,
 				5775CEB226E5DF3300C6AFE3 /* RedirectTests */,
 				3C2B648D27E98858002FAF3E /* TestHost */,
+				3C99E78627EAF1A10074156C /* ApplePay */,
+				3C99E78D27EAF1A20074156C /* ApplePayTests */,
 			);
 		};
 /* End PBXProject section */
@@ -1162,6 +1298,20 @@
 				3C2B64A027E98859002FAF3E /* LaunchScreen.storyboard in Resources */,
 				3C2B649D27E98859002FAF3E /* Assets.xcassets in Resources */,
 				3C2B649B27E98858002FAF3E /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3C99E78527EAF1A10074156C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3C99E78C27EAF1A20074156C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1210,6 +1360,28 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		525628A94F7646EA0BA48A10 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-ApplePayTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		D48332BEDB887DCB4D599389 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1310,6 +1482,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		3C99E78327EAF1A10074156C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3C99E7A527EAF2840074156C /* AWXApplePayProvider.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3C99E78A27EAF1A20074156C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3C5A37D627EAFD9F00CFC2EF /* AWXApplePayProviderTest.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5775CE5B26E5D86100C6AFE3 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1382,6 +1570,22 @@
 			isa = PBXTargetDependency;
 			target = 3C2B648D27E98858002FAF3E /* TestHost */;
 			targetProxy = 3C2B64A727E98863002FAF3E /* PBXContainerItemProxy */;
+		};
+		3C99E79127EAF1A20074156C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3C99E78627EAF1A10074156C /* ApplePay */;
+			targetProxy = 3C99E79027EAF1A20074156C /* PBXContainerItemProxy */;
+		};
+		3C99E7A927EAF4890074156C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			platformFilter = ios;
+			target = 085BD3C723CC62B4002E8F27 /* Core */;
+			targetProxy = 3C99E7A827EAF4890074156C /* PBXContainerItemProxy */;
+		};
+		3C99E7AC27EAF4B90074156C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3C2B648D27E98858002FAF3E /* TestHost */;
+			targetProxy = 3C99E7AB27EAF4B90074156C /* PBXContainerItemProxy */;
 		};
 		5775CE6A26E5D86100C6AFE3 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1692,6 +1896,92 @@
 			};
 			name = Release;
 		};
+		3C99E79627EAF1A20074156C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 Airwallex. All rights reserved.";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 4.0.1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.airwallex.ApplePay;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		3C99E79727EAF1A20074156C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 Airwallex. All rights reserved.";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 4.0.1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.airwallex.ApplePay;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		3C99E79827EAF1A20074156C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 79CC91FEFC20844097DA8051 /* Pods-ApplePayTests.debug.xcconfig */;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.airwallex.ApplePayTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestHost.app/TestHost";
+			};
+			name = Debug;
+		};
+		3C99E79927EAF1A20074156C /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = BD25D2EFD8E73A8E45ECDB24 /* Pods-ApplePayTests.release.xcconfig */;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.airwallex.ApplePayTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestHost.app/TestHost";
+			};
+			name = Release;
+		};
 		5775CE7026E5D86100C6AFE3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 8096B137EDD3F3FFD5786CEB /* Pods-WeChatPay.debug.xcconfig */;
@@ -1985,6 +2275,24 @@
 			buildConfigurations = (
 				3C2B64A527E98859002FAF3E /* Debug */,
 				3C2B64A627E98859002FAF3E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3C99E79A27EAF1A20074156C /* Build configuration list for PBXNativeTarget "ApplePay" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3C99E79627EAF1A20074156C /* Debug */,
+				3C99E79727EAF1A20074156C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3C99E79B27EAF1A20074156C /* Build configuration list for PBXNativeTarget "ApplePayTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3C99E79827EAF1A20074156C /* Debug */,
+				3C99E79927EAF1A20074156C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Airwallex/Airwallex.xcodeproj/xcshareddata/xcschemes/ApplePay.xcscheme
+++ b/Airwallex/Airwallex.xcodeproj/xcshareddata/xcschemes/ApplePay.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1330"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3C99E78627EAF1A10074156C"
+               BuildableName = "ApplePay.framework"
+               BlueprintName = "ApplePay"
+               ReferencedContainer = "container:Airwallex.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3C99E78D27EAF1A20074156C"
+               BuildableName = "ApplePayTests.xctest"
+               BlueprintName = "ApplePayTests"
+               ReferencedContainer = "container:Airwallex.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3C99E78627EAF1A10074156C"
+            BuildableName = "ApplePay.framework"
+            BlueprintName = "ApplePay"
+            ReferencedContainer = "container:Airwallex.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Airwallex/Airwallex.xctestplan
+++ b/Airwallex/Airwallex.xctestplan
@@ -18,6 +18,13 @@
         "identifier" : "085BD3D023CC62B4002E8F27",
         "name" : "CoreTests"
       }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:..\/Airwallex\/Airwallex.xcodeproj",
+        "identifier" : "3C99E78D27EAF1A20074156C",
+        "name" : "ApplePayTests"
+      }
     }
   ],
   "version" : 1

--- a/Airwallex/ApplePay/AWXApplePayProvider.h
+++ b/Airwallex/ApplePay/AWXApplePayProvider.h
@@ -1,0 +1,20 @@
+//
+//  AWXApplePayProvider.h
+//  ApplePay
+//
+//  Created by Jin Wang on 23/3/2022.
+//  Copyright © 2022 Airwallex. All rights reserved.
+//
+
+#import "AWXDefaultProvider.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ `AWXApplePayProvider` is a provider to handle payment method with Apple Pay.
+ */
+@interface AWXApplePayProvider : AWXDefaultProvider
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Airwallex/ApplePay/AWXApplePayProvider.m
+++ b/Airwallex/ApplePay/AWXApplePayProvider.m
@@ -1,0 +1,34 @@
+//
+//  AWXApplePayProvider.m
+//  ApplePay
+//
+//  Created by Jin Wang on 23/3/2022.
+//  Copyright © 2022 Airwallex. All rights reserved.
+//
+
+#import "AWXApplePayProvider.h"
+#import "AWXSession.h"
+
+@implementation AWXApplePayProvider
+
++ (BOOL)canHandleSession:(AWXSession *)session
+{
+    if ([session isKindOfClass:[AWXOneOffSession class]]) {
+        AWXOneOffSession *oneOffSession = (AWXOneOffSession *)session;
+        if (oneOffSession.applePayOptions == nil) {
+            return NO;
+        }
+        return [PKPaymentAuthorizationController canMakePaymentsUsingNetworks:AWXApplePaySupportedNetworks()
+                                                                 capabilities:oneOffSession.applePayOptions.merchantCapabilities];
+    } else {
+        return NO;
+    }
+}
+
+- (void)handleFlow
+{
+    // TODO: This will be replaced with real implementation.
+    [self.delegate provider:self didCompleteWithStatus:AirwallexPaymentStatusSuccess error: nil];
+}
+
+@end

--- a/Airwallex/ApplePay/ApplePay.h
+++ b/Airwallex/ApplePay/ApplePay.h
@@ -1,0 +1,17 @@
+//
+//  ApplePay.h
+//  ApplePay
+//
+//  Created by Jin Wang on 23/3/2022.
+//  Copyright © 2022 Airwallex. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for ApplePay.
+FOUNDATION_EXPORT double ApplePayVersionNumber;
+
+//! Project version string for ApplePay.
+FOUNDATION_EXPORT const unsigned char ApplePayVersionString[];
+
+#import "AWXApplePayProvider.h"

--- a/Airwallex/ApplePayTests/AWXApplePayProviderTest.m
+++ b/Airwallex/ApplePayTests/AWXApplePayProviderTest.m
@@ -1,0 +1,58 @@
+//
+//  AWXApplePayProviderTest.m
+//  ApplePayTests
+//
+//  Created by Jin Wang on 23/3/2022.
+//  Copyright © 2022 Airwallex. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+#import "AWXApplePayProvider.h"
+#import "AWXSession.h"
+
+@interface AWXApplePayProviderTest : XCTestCase
+
+@end
+
+@implementation AWXApplePayProviderTest
+
+- (void)testShouldReturnNOWithRecurringSession {
+    AWXSession *session = [AWXRecurringSession new];
+    XCTAssertFalse([AWXApplePayProvider canHandleSession:session]);
+}
+
+- (void)testShouldReturnNOWithRecurringWithIntentSession {
+    AWXSession *session = [AWXRecurringWithIntentSession new];
+    XCTAssertFalse([AWXApplePayProvider canHandleSession:session]);
+}
+
+- (void)testShouldReturnNOWithoutApplePayOptions {
+    AWXSession *session = [AWXOneOffSession new];
+    session.applePayOptions = nil;
+    XCTAssertFalse([AWXApplePayProvider canHandleSession:session]);
+}
+
+- (void)testShouldReturnNOWhenDeviceCheckFailed {
+    AWXSession *session = [AWXOneOffSession new];
+    session.applePayOptions = [[AWXApplePayOptions alloc] initWithMerchantIdentifier:@"merchantIdentifier"];
+    id classMock = OCMClassMock([PKPaymentAuthorizationController class]);
+    OCMStub([classMock canMakePaymentsUsingNetworks:[OCMArg any] capabilities:0])
+        .ignoringNonObjectArgs()
+        .andReturn(NO);
+    
+    XCTAssertFalse([AWXApplePayProvider canHandleSession:session]);
+}
+
+- (void)testShouldReturnYES {
+    AWXSession *session = [AWXOneOffSession new];
+    session.applePayOptions = [[AWXApplePayOptions alloc] initWithMerchantIdentifier:@"merchantIdentifier"];
+    id classMock = OCMClassMock([PKPaymentAuthorizationController class]);
+    OCMStub([classMock canMakePaymentsUsingNetworks:[OCMArg any] capabilities:0])
+        .ignoringNonObjectArgs()
+        .andReturn(YES);
+    
+    XCTAssertTrue([AWXApplePayProvider canHandleSession:session]);
+}
+
+@end

--- a/Airwallex/Core/Sources/AWXConstants.m
+++ b/Airwallex/Core/Sources/AWXConstants.m
@@ -96,6 +96,8 @@ Class ClassToHandleFlowForPaymentMethodType(AWXPaymentMethodType *type)
 {
     if ([type.name isEqualToString:AWXCardKey]) {
         return NSClassFromString(@"AWXCardProvider");
+    } else if ([type.name isEqualToString:AWXApplePayKey]) {
+        return NSClassFromString(@"AWXApplePayProvider");
     } else if (type.hasSchema) {
         return NSClassFromString(@"AWXSchemaProvider");
     } else {

--- a/Airwallex/CoreTests/AWXConstantsTest.m
+++ b/Airwallex/CoreTests/AWXConstantsTest.m
@@ -8,6 +8,28 @@
 
 #import <XCTest/XCTest.h>
 #import "AWXConstants.h"
+#import "AWXPaymentMethod.h"
+#import "AWXDefaultProvider.h"
+
+# pragma mark - Sample providers for test purposes
+
+@interface AWXApplePayProvider : AWXDefaultProvider
+@end
+
+@implementation AWXApplePayProvider
+@end
+
+@interface AWXCardProvider : AWXDefaultProvider
+@end
+
+@implementation AWXCardProvider
+@end
+
+@interface AWXSchemaProvider : AWXDefaultProvider
+@end
+
+@implementation AWXSchemaProvider
+@end
 
 @interface AWXConstantsTest : XCTestCase
 
@@ -26,6 +48,44 @@
     if (@available(iOS 12.0, *)) {
         XCTAssertTrue([AWXApplePaySupportedNetworks() containsObject:PKPaymentNetworkMaestro]);
     }
+}
+
+- (void)testClassToHandleFlowForPaymentMethodTypeApplePay
+{
+    AWXPaymentMethodType *type = [AWXPaymentMethodType new];
+    type.name = @"applepay";
+    
+    XCTAssertEqualObjects(ClassToHandleFlowForPaymentMethodType(type), [AWXApplePayProvider class]);
+}
+
+- (void)testClassToHandleFlowForPaymentMethodTypeCard
+{
+    AWXPaymentMethodType *type = [AWXPaymentMethodType new];
+    type.name = @"card";
+    
+    XCTAssertEqualObjects(ClassToHandleFlowForPaymentMethodType(type), [AWXCardProvider class]);
+}
+
+- (void)testClassToHandleFlowForPaymentMethodTypeSchema
+{
+    AWXPaymentMethodType *type = [AWXPaymentMethodType new];
+    type.name = @"wechatpay";
+    AWXResources *resources = [AWXResources new];
+    resources.hasSchema = YES;
+    type.resources = resources;
+    
+    XCTAssertEqualObjects(ClassToHandleFlowForPaymentMethodType(type), [AWXSchemaProvider class]);
+}
+
+- (void)testClassToHandleFlowForPaymentMethodTypeDefault
+{
+    AWXPaymentMethodType *type = [AWXPaymentMethodType new];
+    type.name = @"somethingelse";
+    AWXResources *resources = [AWXResources new];
+    resources.hasSchema = NO;
+    type.resources = resources;
+    
+    XCTAssertEqualObjects(ClassToHandleFlowForPaymentMethodType(type), [AWXDefaultProvider class]);
 }
 
 @end

--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		08A3E99D24246C30003FDAAF /* OptionsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OptionsViewController.h; sourceTree = "<group>"; };
 		08A3E99E24246C30003FDAAF /* OptionsViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OptionsViewController.m; sourceTree = "<group>"; };
 		08B55E372421D8C60054E254 /* Airwallex.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Airwallex.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3C5A37D427EAF68F00CFC2EF /* Examples.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Examples.entitlements; sourceTree = "<group>"; };
 		57033F2726958C94008A4780 /* UIViewController+Utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Utils.h"; sourceTree = "<group>"; };
 		57033F2826958C94008A4780 /* UIViewController+Utils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+Utils.m"; sourceTree = "<group>"; };
 		57CEC82526E6005000695740 /* Card.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Card.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -141,6 +142,7 @@
 		085BD3ED23CC64B6002E8F27 /* Examples */ = {
 			isa = PBXGroup;
 			children = (
+				3C5A37D427EAF68F00CFC2EF /* Examples.entitlements */,
 				57DCD641269428C800705D5C /* Keys */,
 				085BD3EE23CC64B6002E8F27 /* AppDelegate.h */,
 				085BD3EF23CC64B6002E8F27 /* AppDelegate.m */,
@@ -507,6 +509,7 @@
 			baseConfigurationReference = 617807456E4EF1973ABF7042 /* Pods-Examples.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = Examples/Examples.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = K294E2HD3N;
@@ -527,6 +530,7 @@
 			baseConfigurationReference = 89340FFBA0BDAB8E114F5872 /* Pods-Examples.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = Examples/Examples.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = K294E2HD3N;

--- a/Examples/Examples/Cart/CartViewController.m
+++ b/Examples/Examples/Cart/CartViewController.m
@@ -276,6 +276,10 @@
         case AirwallexCheckoutOneOffMode:
         {
             AWXOneOffSession *session = [AWXOneOffSession new];
+            
+            AWXApplePayOptions *options = [[AWXApplePayOptions alloc] initWithMerchantIdentifier:@"merchant.com.airwallex.paymentacceptance"];
+            session.applePayOptions = options;
+            
             session.countryCode = [AirwallexExamplesKeys shared].countryCode;
             session.billing = self.shipping;
             session.returnURL = [AirwallexExamplesKeys shared].returnUrl;

--- a/Examples/Examples/Examples.entitlements
+++ b/Examples/Examples/Examples.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.in-app-payments</key>
+	<array>
+		<string>merchant.com.airwallex.paymentacceptance</string>
+	</array>
+</dict>
+</plist>

--- a/Podfile
+++ b/Podfile
@@ -10,9 +10,15 @@ target 'WeChatPay' do
   pod 'WechatOpenSDK', '1.8.7.1'
 end
 
+target 'ApplePayTests' do
+  project './Airwallex/Airwallex.xcodeproj'
+  pod 'OCMock'
+end
+
 target 'Examples' do
   project './Examples/Examples.xcodeproj'
   pod 'Airwallex', :path => './'
+  pod 'Airwallex/ApplePay', :path => './'
   pod 'WechatOpenSDK', '1.8.7.1'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -4,6 +4,8 @@ PODS:
     - Airwallex/Core (= 4.0.1)
     - Airwallex/Redirect (= 4.0.1)
     - Airwallex/WeChatPay (= 4.0.1)
+  - Airwallex/ApplePay (4.0.1):
+    - Airwallex/Core
   - Airwallex/Card (4.0.1):
     - Airwallex/Core
   - Airwallex/Core (4.0.1)
@@ -12,14 +14,18 @@ PODS:
   - Airwallex/WeChatPay (4.0.1):
     - Airwallex/Core
     - WechatOpenSDK
+  - OCMock (3.9.1)
   - WechatOpenSDK (1.8.7.1)
 
 DEPENDENCIES:
   - Airwallex (from `./`)
+  - Airwallex/ApplePay (from `./`)
+  - OCMock
   - WechatOpenSDK (= 1.8.7.1)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
+    - OCMock
     - WechatOpenSDK
 
 EXTERNAL SOURCES:
@@ -27,9 +33,10 @@ EXTERNAL SOURCES:
     :path: "./"
 
 SPEC CHECKSUMS:
-  Airwallex: 6885ef51edc5453ded47ed6522ea93a2e2fd7921
+  Airwallex: 05ad76a7da26cb283efad76635124736f176a6b4
+  OCMock: 9491e4bec59e0b267d52a9184ff5605995e74be8
   WechatOpenSDK: 6a4d1436c15b3b5fe2a0bd383f3046010186da44
 
-PODFILE CHECKSUM: 86b90d9822bc5e5e858f9dead9bb3a189dbe7ae1
+PODFILE CHECKSUM: 8410f5597504bddd60240f641fb29a1f814006f8
 
 COCOAPODS: 1.11.2


### PR DESCRIPTION
This PR:
- introduced `AWXApplePayProvider` to handle Apple Pay payment method. 
- `AWXApplePayProvider` overrides `canHandleSession` to check:
1.  whether a merchant identifier is configured.
2. whether the session is a one off session. For MVP, Apple Pay only supports one off payment.
3. whether the device has a card in Wallet that can support visa, Mastercard, UnionPay or maestro as well as support the merchant capabilities defined in the `AWXApplePayOptions`.

- Added a new subspec in Cocoapods. But it's excluded from the default modules.
- Added Apple Pay capability to the Examples target and used our sample merchant ID (merchant.com.airwallex.paymentacceptance) for testing and demoing purpose.