### PR TITLE
[MOB-758] fix: filtered out unsupported payment methods when presenting the payment method selection sheet

### DIFF
--- a/Airwallex/Airwallex.xcodeproj/project.pbxproj
+++ b/Airwallex/Airwallex.xcodeproj/project.pbxproj
@@ -29,6 +29,12 @@
 		3C2B649D27E98859002FAF3E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3C2B649C27E98859002FAF3E /* Assets.xcassets */; };
 		3C2B64A027E98859002FAF3E /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3C2B649E27E98859002FAF3E /* LaunchScreen.storyboard */; };
 		3C2B64A327E98859002FAF3E /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C2B64A227E98859002FAF3E /* main.m */; };
+		3C324F8827FBE2D300CF7315 /* AWXConstants+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C324F8627FBE2D300CF7315 /* AWXConstants+Internal.h */; };
+		3C324F8927FBE2D300CF7315 /* AWXConstants+Internal.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C324F8727FBE2D300CF7315 /* AWXConstants+Internal.m */; };
+		3C324F9027FC09AD00CF7315 /* AWXSession+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C324F8E27FC09AD00CF7315 /* AWXSession+Internal.h */; };
+		3C324F9127FC09AD00CF7315 /* AWXSession+Internal.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C324F8F27FC09AD00CF7315 /* AWXSession+Internal.m */; };
+		3C324F9327FC0BF200CF7315 /* AWXSessionInternalTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C324F9227FC0BF200CF7315 /* AWXSessionInternalTest.m */; };
+		3C324F9527FC108500CF7315 /* AWXConstantsInternalTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C324F9427FC108500CF7315 /* AWXConstantsInternalTest.m */; };
 		3C455EB627E03B04009DB492 /* RLTMXProfilingConnections.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C455EB327E03B04009DB492 /* RLTMXProfilingConnections.xcframework */; };
 		3C455EB727E03B04009DB492 /* RLTMXProfilingConnections.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3C455EB327E03B04009DB492 /* RLTMXProfilingConnections.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3C455EB827E03B04009DB492 /* RLTMXProfiling.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C455EB427E03B04009DB492 /* RLTMXProfiling.xcframework */; };
@@ -311,6 +317,12 @@
 		3C2B649F27E98859002FAF3E /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		3C2B64A127E98859002FAF3E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3C2B64A227E98859002FAF3E /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		3C324F8627FBE2D300CF7315 /* AWXConstants+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AWXConstants+Internal.h"; sourceTree = "<group>"; };
+		3C324F8727FBE2D300CF7315 /* AWXConstants+Internal.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "AWXConstants+Internal.m"; sourceTree = "<group>"; };
+		3C324F8E27FC09AD00CF7315 /* AWXSession+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AWXSession+Internal.h"; sourceTree = "<group>"; };
+		3C324F8F27FC09AD00CF7315 /* AWXSession+Internal.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "AWXSession+Internal.m"; sourceTree = "<group>"; };
+		3C324F9227FC0BF200CF7315 /* AWXSessionInternalTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWXSessionInternalTest.m; sourceTree = "<group>"; };
+		3C324F9427FC108500CF7315 /* AWXConstantsInternalTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWXConstantsInternalTest.m; sourceTree = "<group>"; };
 		3C455EB327E03B04009DB492 /* RLTMXProfilingConnections.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RLTMXProfilingConnections.xcframework; path = ../TrustDefender/RLTMXProfilingConnections.xcframework; sourceTree = "<group>"; };
 		3C455EB427E03B04009DB492 /* RLTMXProfiling.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RLTMXProfiling.xcframework; path = ../TrustDefender/RLTMXProfiling.xcframework; sourceTree = "<group>"; };
 		3C455EB527E03B04009DB492 /* RLTMXBehavioralBiometrics.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RLTMXBehavioralBiometrics.xcframework; path = ../TrustDefender/RLTMXBehavioralBiometrics.xcframework; sourceTree = "<group>"; };
@@ -679,7 +691,9 @@
 				0829FD5024358E5600557DB2 /* XCTestCase+Utils.m */,
 				3C99E74627E9A6B70074156C /* AWXApplePayOptionsTest.m */,
 				3C99E74427E9A51C0074156C /* AWXConstantsTest.m */,
+				3C324F9427FC108500CF7315 /* AWXConstantsInternalTest.m */,
 				3C99E73E27E9A3380074156C /* AWXDefaultProviderTest.m */,
+				3C324F9227FC0BF200CF7315 /* AWXSessionInternalTest.m */,
 				082442C62431BD5100D04A2C /* AWXTestUtils.h */,
 				082442C72431BD5100D04A2C /* AWXTestUtils.m */,
 				0829FD182432016900557DB2 /* Tools */,
@@ -738,6 +752,8 @@
 				5775CEF726E5DF4F00C6AFE3 /* AWXAPIResponse.m */,
 				5775CEC426E5DF4D00C6AFE3 /* AWXCardValidator.h */,
 				5775CEC726E5DF4D00C6AFE3 /* AWXCardValidator.m */,
+				3C324F8627FBE2D300CF7315 /* AWXConstants+Internal.h */,
+				3C324F8727FBE2D300CF7315 /* AWXConstants+Internal.m */,
 				5775CEF426E5DF4F00C6AFE3 /* AWXCountry.h */,
 				5775CED126E5DF4D00C6AFE3 /* AWXCountry.m */,
 				5775CEEB26E5DF4E00C6AFE3 /* AWXCountryListViewController.h */,
@@ -772,6 +788,8 @@
 				5775CF0526E5DF4F00C6AFE3 /* AWXPaymentMethodResponse.m */,
 				5775CF0C26E5DF4F00C6AFE3 /* AWXPaymentViewController.h */,
 				5775CECD26E5DF4D00C6AFE3 /* AWXPaymentViewController.m */,
+				3C324F8E27FC09AD00CF7315 /* AWXSession+Internal.h */,
+				3C324F8F27FC09AD00CF7315 /* AWXSession+Internal.m */,
 				5775CF0A26E5DF4F00C6AFE3 /* AWXTrackManager.h */,
 				5775CEE526E5DF4E00C6AFE3 /* AWXTrackManager.m */,
 			);
@@ -1007,6 +1025,7 @@
 				5775CF4E26E5DF5000C6AFE3 /* AWXDevice.h in Headers */,
 				5775CF1226E5DF4F00C6AFE3 /* AWXPaymentIntent.h in Headers */,
 				5775CF2A26E5DF4F00C6AFE3 /* AWXPlaceDetails.h in Headers */,
+				3C324F8827FBE2D300CF7315 /* AWXConstants+Internal.h in Headers */,
 				5775CF2F26E5DF4F00C6AFE3 /* AWXSession.h in Headers */,
 				5775CF4A26E5DF5000C6AFE3 /* AWXCodable.h in Headers */,
 				5775CF6126E5DF5000C6AFE3 /* AWXShippingViewController.h in Headers */,
@@ -1021,6 +1040,7 @@
 				5775CF3326E5DF4F00C6AFE3 /* AWXPaymentMethodRequest.h in Headers */,
 				5775CF3626E5DF4F00C6AFE3 /* AWXForm.h in Headers */,
 				5775CF5926E5DF5000C6AFE3 /* AWXPaymentMethod.h in Headers */,
+				3C324F9027FC09AD00CF7315 /* AWXSession+Internal.h in Headers */,
 				5775CF5C26E5DF5000C6AFE3 /* AWXPaymentViewController.h in Headers */,
 				5775CF2826E5DF4F00C6AFE3 /* AWXAPIResponse.h in Headers */,
 				5775CF5B26E5DF5000C6AFE3 /* AWXPaymentIntentRequest.h in Headers */,
@@ -1583,6 +1603,7 @@
 				5775CF1F26E5DF4F00C6AFE3 /* AWXPaymentMethodOptions.m in Sources */,
 				5775CF3C26E5DF5000C6AFE3 /* AWXFormMapping.m in Sources */,
 				5775CF4B26E5DF5000C6AFE3 /* AWXPaymentConsentResponse.m in Sources */,
+				3C324F9127FC09AD00CF7315 /* AWXSession+Internal.m in Sources */,
 				5775CF1E26E5DF4F00C6AFE3 /* AWXPaymentMethodCell.m in Sources */,
 				5775CF3426E5DF4F00C6AFE3 /* AWXCard.m in Sources */,
 				5775CF5826E5DF5000C6AFE3 /* AWXAPIClient.m in Sources */,
@@ -1607,6 +1628,7 @@
 				5775CF3226E5DF4F00C6AFE3 /* AWXPaymentIntentRequest.m in Sources */,
 				5775CF4226E5DF5000C6AFE3 /* AWXShippingViewController.m in Sources */,
 				5775CF2926E5DF4F00C6AFE3 /* AWXDevice.m in Sources */,
+				3C324F8927FBE2D300CF7315 /* AWXConstants+Internal.m in Sources */,
 				5775CF5626E5DF5000C6AFE3 /* AWXPaymentMethodRequest.m in Sources */,
 				5775CF2126E5DF4F00C6AFE3 /* AWXCountry.m in Sources */,
 				5775CF1826E5DF4F00C6AFE3 /* AWXPlaceDetails.m in Sources */,
@@ -1622,8 +1644,10 @@
 				0829FD1A2432019E00557DB2 /* AWXCardValidatorTest.m in Sources */,
 				0829FD4E243584E300557DB2 /* AWXTestAPIClient.m in Sources */,
 				0829FD022431D10800557DB2 /* AWXAddressTest.m in Sources */,
+				3C324F9327FC0BF200CF7315 /* AWXSessionInternalTest.m in Sources */,
 				3C99E73F27E9A3380074156C /* AWXDefaultProviderTest.m in Sources */,
 				082442CC2431C00E00D04A2C /* AWXCardTest.m in Sources */,
+				3C324F9527FC108500CF7315 /* AWXConstantsInternalTest.m in Sources */,
 				572D1BEE26DF4D06001EBDAA /* AWXSessionTest.m in Sources */,
 				0829FD082431D25800557DB2 /* AWXBillingTest.m in Sources */,
 				3C99E74727E9A6B70074156C /* AWXApplePayOptionsTest.m in Sources */,

--- a/Airwallex/ApplePay/AWXApplePayProvider.m
+++ b/Airwallex/ApplePay/AWXApplePayProvider.m
@@ -80,9 +80,7 @@
     [controller presentWithCompletion:^(BOOL success) {
         __strong __typeof(weakSelf)strongSelf = weakSelf;
         
-        if (success) {
-            NSLog(@"PKPaymentAuthorizationController presents succesfully!");
-        } else {
+        if (!success) {
             NSError *error = [NSError errorWithDomain:AWXSDKErrorDomain
                                                  code:-1
                                              userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Failed to present PKPaymentAuthorizationController.", nil)}];

--- a/Airwallex/Core/Sources/Internal/AWXConstants+Internal.h
+++ b/Airwallex/Core/Sources/Internal/AWXConstants+Internal.h
@@ -1,0 +1,15 @@
+//
+//  AWXConstants+Internal.h
+//  Core
+//
+//  Created by Jin Wang on 5/4/2022.
+//  Copyright © 2022 Airwallex. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+FOUNDATION_EXPORT NSArray <NSString *> *AWXUnsupportedPaymentMethodTypes(void);
+
+NS_ASSUME_NONNULL_END

--- a/Airwallex/Core/Sources/Internal/AWXConstants+Internal.m
+++ b/Airwallex/Core/Sources/Internal/AWXConstants+Internal.m
@@ -1,0 +1,20 @@
+//
+//  AWXConstants+Internal.m
+//  Core
+//
+//  Created by Jin Wang on 5/4/2022.
+//  Copyright © 2022 Airwallex. All rights reserved.
+//
+
+#import "AWXConstants+Internal.h"
+
+NSArray <NSString *> *AWXUnsupportedPaymentMethodTypes(void)
+{
+    return @[
+        @"googlepay",
+        @"ach_direct_debit",
+        @"becs_direct_debit",
+        @"sepa_direct_debit",
+        @"bacs_direct_debit"
+    ];
+}

--- a/Airwallex/Core/Sources/Internal/AWXPaymentMethodListViewController.m
+++ b/Airwallex/Core/Sources/Internal/AWXPaymentMethodListViewController.m
@@ -126,7 +126,7 @@
 
         if (response && !error) {
             AWXGetPaymentMethodTypesResponse *result = (AWXGetPaymentMethodTypesResponse *)response;
-            strongSelf.availablePaymentMethodTypes = [self.session filterPaymentMethodTypes:result.items];
+            strongSelf.availablePaymentMethodTypes = [self.session filteredPaymentMethodTypes:result.items];
             strongSelf.canLoadMore = result.hasMore;
             strongSelf.nextPageNum = pageNum + 1;
             [strongSelf.tableView reloadData];

--- a/Airwallex/Core/Sources/Internal/AWXPaymentMethodListViewController.m
+++ b/Airwallex/Core/Sources/Internal/AWXPaymentMethodListViewController.m
@@ -30,6 +30,7 @@
 #import "AWXForm.h"
 #import "AWXDefaultProvider.h"
 #import "AWXDefaultActionProvider.h"
+#import "AWXSession+Internal.h"
 
 @interface AWXPaymentMethodListViewController () <UITableViewDataSource, UITableViewDelegate, UIScrollViewDelegate, AWXProviderDelegate>
 
@@ -125,30 +126,12 @@
 
         if (response && !error) {
             AWXGetPaymentMethodTypesResponse *result = (AWXGetPaymentMethodTypesResponse *)response;
-            strongSelf.availablePaymentMethodTypes = [self filterPaymentMethodTypes:result.items];
+            strongSelf.availablePaymentMethodTypes = [self.session filterPaymentMethodTypes:result.items];
             strongSelf.canLoadMore = result.hasMore;
             strongSelf.nextPageNum = pageNum + 1;
             [strongSelf.tableView reloadData];
         }
     }];
-}
-
-- (NSArray<AWXPaymentMethodType *> *)filterPaymentMethodTypes:(NSArray<AWXPaymentMethodType *> *)items
-{
-    NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(id  _Nullable evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {
-        AWXPaymentMethodType *item = (AWXPaymentMethodType *)evaluatedObject;
-        Class class = ClassToHandleFlowForPaymentMethodType(item);
-        
-        // If no provider is available or if the provider is not able to handle the particular session,
-        // then we should filter this method out.
-        if (class == nil || ![class canHandleSession: self.session]) {
-            return NO;
-        }
-        
-        return [item.transactionMode isEqualToString:self.session.transactionMode];
-    }];
-    
-    return [items filteredArrayUsingPredicate:predicate];
 }
 
 - (void)loadAvailablePaymentConsents

--- a/Airwallex/Core/Sources/Internal/AWXSession+Internal.h
+++ b/Airwallex/Core/Sources/Internal/AWXSession+Internal.h
@@ -1,0 +1,20 @@
+//
+//  AWXSession+Internal.h
+//  Core
+//
+//  Created by Jin Wang on 5/4/2022.
+//  Copyright © 2022 Airwallex. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "AWXSession.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface AWXSession (Internal)
+
+- (NSArray <AWXPaymentMethodType *> *)filterPaymentMethodTypes:(NSArray<AWXPaymentMethodType *> *)items;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Airwallex/Core/Sources/Internal/AWXSession+Internal.h
+++ b/Airwallex/Core/Sources/Internal/AWXSession+Internal.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface AWXSession (Internal)
 
-- (NSArray <AWXPaymentMethodType *> *)filterPaymentMethodTypes:(NSArray<AWXPaymentMethodType *> *)items;
+- (NSArray <AWXPaymentMethodType *> *)filteredPaymentMethodTypes:(NSArray<AWXPaymentMethodType *> *)items;
 
 @end
 

--- a/Airwallex/Core/Sources/Internal/AWXSession+Internal.m
+++ b/Airwallex/Core/Sources/Internal/AWXSession+Internal.m
@@ -1,0 +1,40 @@
+//
+//  AWXSession+Internal.m
+//  Core
+//
+//  Created by Jin Wang on 5/4/2022.
+//  Copyright © 2022 Airwallex. All rights reserved.
+//
+
+#import "AWXPaymentMethod.h"
+#import "AWXConstants+Internal.h"
+#import "AWXDefaultProvider.h"
+#import "AWXSession+Internal.h"
+
+@implementation AWXSession (Internal)
+
+- (NSArray<AWXPaymentMethodType *> *)filterPaymentMethodTypes:(NSArray<AWXPaymentMethodType *> *)items
+{
+    NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(id  _Nullable evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {
+        AWXPaymentMethodType *item = (AWXPaymentMethodType *)evaluatedObject;
+        
+        // Filter out unsupported payment methods.
+        if ([AWXUnsupportedPaymentMethodTypes() containsObject:item.name]) {
+            return NO;
+        }
+        
+        Class class = ClassToHandleFlowForPaymentMethodType(item);
+        
+        // If no provider is available or if the provider is not able to handle the particular session,
+        // then we should filter this method out.
+        if (class == nil || ![class canHandleSession: self]) {
+            return NO;
+        }
+        
+        return [item.transactionMode isEqualToString:self.transactionMode];
+    }];
+    
+    return [items filteredArrayUsingPredicate:predicate];
+}
+
+@end

--- a/Airwallex/Core/Sources/Internal/AWXSession+Internal.m
+++ b/Airwallex/Core/Sources/Internal/AWXSession+Internal.m
@@ -13,7 +13,7 @@
 
 @implementation AWXSession (Internal)
 
-- (NSArray<AWXPaymentMethodType *> *)filterPaymentMethodTypes:(NSArray<AWXPaymentMethodType *> *)items
+- (NSArray<AWXPaymentMethodType *> *)filteredPaymentMethodTypes:(NSArray<AWXPaymentMethodType *> *)items
 {
     NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(id  _Nullable evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {
         AWXPaymentMethodType *item = (AWXPaymentMethodType *)evaluatedObject;

--- a/Airwallex/CoreTests/AWXConstantsInternalTest.m
+++ b/Airwallex/CoreTests/AWXConstantsInternalTest.m
@@ -1,0 +1,30 @@
+//
+//  AWXConstantsInternalTest.m
+//  CoreTests
+//
+//  Created by Jin Wang on 5/4/2022.
+//  Copyright © 2022 Airwallex. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "AWXConstants+Internal.h"
+
+@interface AWXConstantsInternalTest : XCTestCase
+
+@end
+
+@implementation AWXConstantsInternalTest
+
+- (void)testUnsupportedPaymentMethodTypes {
+    NSArray *expected = @[
+        @"googlepay",
+        @"ach_direct_debit",
+        @"becs_direct_debit",
+        @"sepa_direct_debit",
+        @"bacs_direct_debit"
+    ];
+    
+    XCTAssertEqualObjects(AWXUnsupportedPaymentMethodTypes(), expected);
+}
+
+@end

--- a/Airwallex/CoreTests/AWXSessionInternalTest.m
+++ b/Airwallex/CoreTests/AWXSessionInternalTest.m
@@ -1,0 +1,73 @@
+//
+//  AWXSessionInternalTest.m
+//  CoreTests
+//
+//  Created by Jin Wang on 5/4/2022.
+//  Copyright © 2022 Airwallex. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+#import "AWXDefaultProvider.h"
+#import "AWXPaymentMethod.h"
+#import "AWXSession+Internal.h"
+
+@interface AWXSessionInternalTest : XCTestCase
+
+@end
+
+@implementation AWXSessionInternalTest
+
+- (void)testShouldFilterOutMismatchTransactionModeAndUnsupportedTypes {
+    AWXSession *session = [AWXSession new];
+    AWXSession *sessionMock = OCMPartialMock(session);
+    
+    OCMStub([sessionMock transactionMode]).andReturn(@"transactionMode");
+    
+    AWXPaymentMethodType *validMethod = [AWXPaymentMethodType new];
+    validMethod.name = @"validMethod";
+    validMethod.transactionMode = @"transactionMode";
+    
+    AWXPaymentMethodType *mismatchTransactionMode = [AWXPaymentMethodType new];
+    mismatchTransactionMode.name = @"mismatchTransactionMode";
+    mismatchTransactionMode.transactionMode = @"anotherTransactionMode";
+    
+    AWXPaymentMethodType *unsupportedMethod = [AWXPaymentMethodType new];
+    unsupportedMethod.name = @"googlepay";
+    unsupportedMethod.transactionMode = @"transactionMode";
+    
+    NSArray<AWXPaymentMethodType *> *methodTypes = @[
+        validMethod,
+        mismatchTransactionMode,
+        unsupportedMethod
+    ];
+    
+    NSArray<AWXPaymentMethodType *> *filtered = [sessionMock filterPaymentMethodTypes:methodTypes];
+    
+    XCTAssertEqual(filtered.count, 1);
+    XCTAssertEqualObjects(filtered[0], validMethod);
+}
+
+- (void)testShouldFilterOutWhenProviderCannotHandleSession {
+    AWXSession *session = [AWXSession new];
+    AWXSession *sessionMock = OCMPartialMock(session);
+    
+    OCMStub([sessionMock transactionMode]).andReturn(@"transactionMode");
+    
+    id classMock = OCMClassMock([AWXDefaultProvider class]);
+    OCMStub([classMock canHandleSession:[OCMArg any]]).andReturn(NO);
+    
+    AWXPaymentMethodType *validMethod = [AWXPaymentMethodType new];
+    validMethod.name = @"validMethod";
+    validMethod.transactionMode = @"transactionMode";
+    
+    NSArray<AWXPaymentMethodType *> *methodTypes = @[
+        validMethod
+    ];
+    
+    NSArray<AWXPaymentMethodType *> *filtered = [sessionMock filterPaymentMethodTypes:methodTypes];
+    
+    XCTAssertEqual(filtered.count, 0);
+}
+
+@end

--- a/Airwallex/CoreTests/AWXSessionInternalTest.m
+++ b/Airwallex/CoreTests/AWXSessionInternalTest.m
@@ -42,7 +42,7 @@
         unsupportedMethod
     ];
     
-    NSArray<AWXPaymentMethodType *> *filtered = [sessionMock filterPaymentMethodTypes:methodTypes];
+    NSArray<AWXPaymentMethodType *> *filtered = [sessionMock filteredPaymentMethodTypes:methodTypes];
     
     XCTAssertEqual(filtered.count, 1);
     XCTAssertEqualObjects(filtered[0], validMethod);
@@ -65,7 +65,7 @@
         validMethod
     ];
     
-    NSArray<AWXPaymentMethodType *> *filtered = [sessionMock filterPaymentMethodTypes:methodTypes];
+    NSArray<AWXPaymentMethodType *> *filtered = [sessionMock filteredPaymentMethodTypes:methodTypes];
     
     XCTAssertEqual(filtered.count, 0);
 }


### PR DESCRIPTION
This PR filtered out unsupported payment method types as a short term solution.

In long term, ideally, the payment intent API should handle this for us.