### PR TITLE
fix: fixed a few issues with the SDK

### DIFF
--- a/Airwallex/Airwallex.xcodeproj/project.pbxproj
+++ b/Airwallex/Airwallex.xcodeproj/project.pbxproj
@@ -67,6 +67,12 @@
 		3C99E7A527EAF2840074156C /* AWXApplePayProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C99E7A327EAF2840074156C /* AWXApplePayProvider.m */; };
 		3C99E7A627EAF4890074156C /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 085BD3C823CC62B4002E8F27 /* Core.framework */; platformFilter = ios; };
 		3C9ED16F27E97E800056615A /* AirwallexCore.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 08D26F532404B6C3008E65D3 /* AirwallexCore.bundle */; };
+		3CE9BA272806D2A5005B70C3 /* PKContact+Request.h in Headers */ = {isa = PBXBuildFile; fileRef = 3CE9BA252806D2A5005B70C3 /* PKContact+Request.h */; };
+		3CE9BA282806D2A5005B70C3 /* PKContact+Request.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CE9BA262806D2A5005B70C3 /* PKContact+Request.m */; };
+		3CE9BA2A2806D923005B70C3 /* PKContactRequestTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CE9BA292806D923005B70C3 /* PKContactRequestTest.m */; };
+		3CE9BA2D2806DE74005B70C3 /* AWXPlaceDetails+PKContact.h in Headers */ = {isa = PBXBuildFile; fileRef = 3CE9BA2B2806DE74005B70C3 /* AWXPlaceDetails+PKContact.h */; };
+		3CE9BA2E2806DE74005B70C3 /* AWXPlaceDetails+PKContact.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CE9BA2C2806DE74005B70C3 /* AWXPlaceDetails+PKContact.m */; };
+		3CE9BA302806E02F005B70C3 /* AWXPlaceDetailsPKContactTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CE9BA2F2806E02F005B70C3 /* AWXPlaceDetailsPKContactTest.m */; };
 		571D10862796DE4D005DE2CA /* WeChatPay.h in Headers */ = {isa = PBXBuildFile; fileRef = 57CEC82426E5FE2A00695740 /* WeChatPay.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		572D1BEE26DF4D06001EBDAA /* AWXSessionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 572D1BED26DF4D06001EBDAA /* AWXSessionTest.m */; };
 		5775CE6826E5D86100C6AFE3 /* WeChatPay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5775CE5F26E5D86100C6AFE3 /* WeChatPay.framework */; };
@@ -352,6 +358,12 @@
 		3C99E78E27EAF1A20074156C /* ApplePayTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ApplePayTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3C99E7A227EAF2840074156C /* AWXApplePayProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AWXApplePayProvider.h; sourceTree = "<group>"; };
 		3C99E7A327EAF2840074156C /* AWXApplePayProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWXApplePayProvider.m; sourceTree = "<group>"; };
+		3CE9BA252806D2A5005B70C3 /* PKContact+Request.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PKContact+Request.h"; sourceTree = "<group>"; };
+		3CE9BA262806D2A5005B70C3 /* PKContact+Request.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "PKContact+Request.m"; sourceTree = "<group>"; };
+		3CE9BA292806D923005B70C3 /* PKContactRequestTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PKContactRequestTest.m; sourceTree = "<group>"; };
+		3CE9BA2B2806DE74005B70C3 /* AWXPlaceDetails+PKContact.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AWXPlaceDetails+PKContact.h"; sourceTree = "<group>"; };
+		3CE9BA2C2806DE74005B70C3 /* AWXPlaceDetails+PKContact.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "AWXPlaceDetails+PKContact.m"; sourceTree = "<group>"; };
+		3CE9BA2F2806E02F005B70C3 /* AWXPlaceDetailsPKContactTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWXPlaceDetailsPKContactTest.m; sourceTree = "<group>"; };
 		3CF4FED827E95F1C00FB0CE4 /* Airwallex.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = Airwallex.xctestplan; sourceTree = "<group>"; };
 		570A139C25A82B270064B362 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../../README.md; sourceTree = "<group>"; };
 		570A139D25A82B280064B362 /* README_zh_CN.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = README_zh_CN.md; path = ../../README_zh_CN.md; sourceTree = "<group>"; };
@@ -741,6 +753,10 @@
 				3C5A37EA27ED491100CFC2EF /* AWXPaymentIntent+Summary.m */,
 				3C5A37ED27ED4A0500CFC2EF /* AWXOneOffSession+Request.h */,
 				3C5A37EE27ED4A0500CFC2EF /* AWXOneOffSession+Request.m */,
+				3CE9BA252806D2A5005B70C3 /* PKContact+Request.h */,
+				3CE9BA262806D2A5005B70C3 /* PKContact+Request.m */,
+				3CE9BA2B2806DE74005B70C3 /* AWXPlaceDetails+PKContact.h */,
+				3CE9BA2C2806DE74005B70C3 /* AWXPlaceDetails+PKContact.m */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
@@ -863,6 +879,8 @@
 				3C5A37F327ED53F400CFC2EF /* PKPaymentTokenRequestTest.m */,
 				3C5A37F527ED65C200CFC2EF /* AWXPaymentIntentSummaryTest.m */,
 				3C5A37F727ED677C00CFC2EF /* AWXOneOffSessionRequestTest.m */,
+				3CE9BA292806D923005B70C3 /* PKContactRequestTest.m */,
+				3CE9BA2F2806E02F005B70C3 /* AWXPlaceDetailsPKContactTest.m */,
 			);
 			path = ApplePayTests;
 			sourceTree = "<group>";
@@ -1063,11 +1081,13 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3CE9BA272806D2A5005B70C3 /* PKContact+Request.h in Headers */,
 				3C5A37E727ED451600CFC2EF /* PKPaymentToken+Request.h in Headers */,
 				3C5A37EB27ED491100CFC2EF /* AWXPaymentIntent+Summary.h in Headers */,
 				3C5A37E327ED443E00CFC2EF /* PKPaymentMethod+Request.h in Headers */,
 				3C5A37EF27ED4A0500CFC2EF /* AWXOneOffSession+Request.h in Headers */,
 				3C99E7A427EAF2840074156C /* AWXApplePayProvider.h in Headers */,
+				3CE9BA2D2806DE74005B70C3 /* AWXPlaceDetails+PKContact.h in Headers */,
 				3C99E79527EAF1A20074156C /* ApplePay.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1678,7 +1698,9 @@
 				3C5A37E827ED451600CFC2EF /* PKPaymentToken+Request.m in Sources */,
 				3C5A37EC27ED491100CFC2EF /* AWXPaymentIntent+Summary.m in Sources */,
 				3C5A37F027ED4A0500CFC2EF /* AWXOneOffSession+Request.m in Sources */,
+				3CE9BA2E2806DE74005B70C3 /* AWXPlaceDetails+PKContact.m in Sources */,
 				3C5A37E427ED443E00CFC2EF /* PKPaymentMethod+Request.m in Sources */,
+				3CE9BA282806D2A5005B70C3 /* PKContact+Request.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1689,6 +1711,8 @@
 				3C5A37F427ED53F400CFC2EF /* PKPaymentTokenRequestTest.m in Sources */,
 				3C5A37F827ED677C00CFC2EF /* AWXOneOffSessionRequestTest.m in Sources */,
 				3C5A37F227ED4EB600CFC2EF /* PKPaymentMethodRequestTest.m in Sources */,
+				3CE9BA302806E02F005B70C3 /* AWXPlaceDetailsPKContactTest.m in Sources */,
+				3CE9BA2A2806D923005B70C3 /* PKContactRequestTest.m in Sources */,
 				3C5A37FF27F2DDB400CFC2EF /* AWXProviderDelegateSpy.m in Sources */,
 				3C5A37F627ED65C200CFC2EF /* AWXPaymentIntentSummaryTest.m in Sources */,
 				3C5A37D627EAFD9F00CFC2EF /* AWXApplePayProviderTest.m in Sources */,

--- a/Airwallex/ApplePay/AWXApplePayProvider.m
+++ b/Airwallex/ApplePay/AWXApplePayProvider.m
@@ -16,6 +16,7 @@
 #import "AWXPaymentIntentResponse.h"
 #import "PKPaymentToken+Request.h"
 #import "AWXOneOffSession+Request.h"
+#import "PKContact+Request.h"
 
 @interface AWXApplePayProvider () <PKPaymentAuthorizationControllerDelegate>
 
@@ -100,11 +101,15 @@
     AWXPaymentMethod *method = [AWXPaymentMethod new];
     method.type = AWXApplePayKey;
     method.customerId = self.session.customerId;
-    method.billing = self.session.billing;
     
     NSError *error;
+    NSDictionary *billingPayload;
     
-    NSDictionary *applePayParams = [payment.token payloadForRequestOrError:&error];
+    if (payment.billingContact) {
+        billingPayload = [payment.billingContact payloadForRequest];
+    }
+    
+    NSDictionary *applePayParams = [payment.token payloadForRequestWithBilling:billingPayload orError:&error];
     
     if (!applePayParams) {
         self.lastError = error;

--- a/Airwallex/ApplePay/Internal/AWXPaymentIntent+Summary.h
+++ b/Airwallex/ApplePay/Internal/AWXPaymentIntent+Summary.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface AWXPaymentIntent (Summary)
 
-- (NSArray <PKPaymentSummaryItem *> *)paymentSummaryItemsWithTotalPriceLabel:(nullable NSString *)label;
+- (PKPaymentSummaryItem *)paymentSummaryItemWithTotalPriceLabel:(nullable NSString *)label;
 
 @end
 

--- a/Airwallex/ApplePay/Internal/AWXPaymentIntent+Summary.m
+++ b/Airwallex/ApplePay/Internal/AWXPaymentIntent+Summary.m
@@ -10,7 +10,7 @@
 
 @implementation AWXPaymentIntent (Summary)
 
-- (NSArray<PKPaymentSummaryItem *> *)paymentSummaryItemsWithTotalPriceLabel:(nullable NSString *)label
+- (PKPaymentSummaryItem *)paymentSummaryItemWithTotalPriceLabel:(nullable NSString *)label
 {
     PKPaymentSummaryItem *item = [PKPaymentSummaryItem new];
     item.type = PKPaymentSummaryItemTypeFinal;
@@ -21,7 +21,7 @@
         item.label = @"";
     }
     
-    return @[item];
+    return item;
 }
 
 @end

--- a/Airwallex/ApplePay/Internal/AWXPlaceDetails+PKContact.h
+++ b/Airwallex/ApplePay/Internal/AWXPlaceDetails+PKContact.h
@@ -1,0 +1,21 @@
+//
+//  AWXPlaceDetails+PKContact.h
+//  ApplePay
+//
+//  Created by Jin Wang on 13/4/2022.
+//  Copyright © 2022 Airwallex. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <PassKit/PassKit.h>
+#import "AWXPlaceDetails.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface AWXPlaceDetails (PKContact)
+
+- (PKContact *)convertToPaymentContact;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Airwallex/ApplePay/Internal/AWXPlaceDetails+PKContact.m
+++ b/Airwallex/ApplePay/Internal/AWXPlaceDetails+PKContact.m
@@ -1,0 +1,42 @@
+//
+//  AWXPlaceDetails+PKContact.m
+//  ApplePay
+//
+//  Created by Jin Wang on 13/4/2022.
+//  Copyright © 2022 Airwallex. All rights reserved.
+//
+
+#import "AWXPlaceDetails+PKContact.h"
+
+@implementation AWXPlaceDetails (PKContact)
+
+- (PKContact *)convertToPaymentContact
+{
+    PKContact *contact = [PKContact new];
+    
+    NSPersonNameComponents *nameComponents = [NSPersonNameComponents new];
+    nameComponents.givenName = self.firstName;
+    nameComponents.familyName = self.lastName;
+    
+    CNMutablePostalAddress *address = [CNMutablePostalAddress new];
+    address.ISOCountryCode = self.address.countryCode;
+    address.city = self.address.city;
+    address.street = self.address.street;
+    
+    if (self.address.state) {
+        address.state = self.address.state;
+    }
+    
+    if (self.address.postcode) {
+        address.postalCode = self.address.postcode;
+    }
+    
+    contact.name = nameComponents;
+    contact.emailAddress = self.email;
+    contact.phoneNumber = [CNPhoneNumber phoneNumberWithStringValue:self.phoneNumber];
+    contact.postalAddress = address;
+    
+    return contact;
+}
+
+@end

--- a/Airwallex/ApplePay/Internal/PKContact+Request.h
+++ b/Airwallex/ApplePay/Internal/PKContact+Request.h
@@ -1,0 +1,20 @@
+//
+//  PKContact+Request.h
+//  ApplePay
+//
+//  Created by Jin Wang on 13/4/2022.
+//  Copyright © 2022 Airwallex. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <PassKit/PassKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface PKContact (Request)
+
+- (NSDictionary *)payloadForRequest;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Airwallex/ApplePay/Internal/PKContact+Request.m
+++ b/Airwallex/ApplePay/Internal/PKContact+Request.m
@@ -1,0 +1,43 @@
+//
+//  PKContact+Request.m
+//  ApplePay
+//
+//  Created by Jin Wang on 13/4/2022.
+//  Copyright © 2022 Airwallex. All rights reserved.
+//
+
+#import "PKContact+Request.h"
+
+@implementation PKContact (Request)
+
+- (NSDictionary *)payloadForRequest
+{
+    NSMutableDictionary *billing = [NSMutableDictionary dictionary];
+    
+    if (self.name) {
+        billing[@"first_name"] = self.name.givenName;
+        billing[@"last_name"] = self.name.familyName;
+    }
+    
+    billing[@"email"] = self.emailAddress;
+    
+    if (self.phoneNumber) {
+        billing[@"phone_number"] = self.phoneNumber.stringValue;
+    }
+    
+    CNPostalAddress *postalAddress = self.postalAddress;
+    
+    if (postalAddress) {
+        billing[@"address"] = @{
+            @"city": postalAddress.city,
+            @"country_code": postalAddress.ISOCountryCode,
+            @"postcode": postalAddress.postalCode,
+            @"state": postalAddress.state,
+            @"street": postalAddress.street
+        };
+    }
+    
+    return billing;
+}
+
+@end

--- a/Airwallex/ApplePay/Internal/PKPaymentToken+Request.h
+++ b/Airwallex/ApplePay/Internal/PKPaymentToken+Request.h
@@ -12,7 +12,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface PKPaymentToken (Request)
 
-- (nullable NSDictionary *)payloadForRequestOrError:(NSError * _Nullable *)error;
+- (nullable NSDictionary *)payloadForRequestWithBilling:(nullable NSDictionary *)billingPayload
+                                                orError:(NSError * _Nullable *)error;
 
 @end
 

--- a/Airwallex/ApplePay/Internal/PKPaymentToken+Request.m
+++ b/Airwallex/ApplePay/Internal/PKPaymentToken+Request.m
@@ -11,7 +11,8 @@
 
 @implementation PKPaymentToken (Request)
 
-- (nullable NSDictionary *)payloadForRequestOrError:(NSError * _Nullable *)error
+- (nullable NSDictionary *)payloadForRequestWithBilling:(nullable NSDictionary *)billingPayload
+                                                orError:(NSError * _Nullable *)error;
 {
     NSData *paymentData = self.paymentData;
     NSDictionary *paymentJSON = [NSJSONSerialization JSONObjectWithData:paymentData
@@ -24,7 +25,13 @@
     
     NSDictionary *header = paymentJSON[@"header"];
     
-    return @{
+    NSMutableDictionary *payload = [NSMutableDictionary dictionary];
+    
+    if (billingPayload) {
+        payload[@"billing"] = billingPayload;
+    }
+    
+    [payload addEntriesFromDictionary:@{
         @"card_brand": self.paymentMethod.network.lowercaseString,
         @"card_type": self.paymentMethod.typeNameForRequest,
         @"data": paymentJSON[@"data"],
@@ -33,7 +40,9 @@
         @"transaction_id": header[@"transactionId"],
         @"signature": paymentJSON[@"signature"],
         @"version": paymentJSON[@"version"]
-    };
+    }];
+    
+    return payload;
 }
 
 @end

--- a/Airwallex/ApplePayTests/AWXOneOffSessionRequestTest.m
+++ b/Airwallex/ApplePayTests/AWXOneOffSessionRequestTest.m
@@ -8,6 +8,7 @@
 
 #import <XCTest/XCTest.h>
 #import "AWXOneOffSession+Request.h"
+#import "AWXPlaceDetails+PKContact.h"
 
 @interface AWXOneOffSessionRequestTest : XCTestCase
 
@@ -20,40 +21,26 @@
     AWXOneOffSession *session = [AWXOneOffSession new];
     session.countryCode = @"AU";
     
+    AWXPlaceDetails *details = [AWXPlaceDetails new];
+    details.firstName = @"firstName";
+    details.lastName = @"lastName";
+    
+    AWXAddress *address = [AWXAddress new];
+    address.street = @"street";
+    address.countryCode = @"AU";
+    address.city = @"city";
+    
+    details.address = address;
+    
+    session.billing = details;
+    
     AWXPaymentIntent *intent = [AWXPaymentIntent new];
     session.paymentIntent = intent;
     intent.currency = @"AUD";
     intent.amount = [[NSDecimalNumber alloc] initWithInt:50];
     
-    NSString *merchantIdentifier = @"merchantIdentifier";
-    AWXApplePayOptions *options = [[AWXApplePayOptions alloc] initWithMerchantIdentifier:merchantIdentifier];
+    AWXApplePayOptions *options = [self makeOptions:nil];
     session.applePayOptions = options;
-    options.supportedCountries = [NSSet setWithObjects:@"AU", @"US", nil];
-    options.shippingType = PKShippingTypeDelivery;
-    options.totalPriceLabel = @"totalPrice";
-    
-    PKContact *shippingContact = [PKContact new];
-    shippingContact.phoneNumber = [[CNPhoneNumber alloc] initWithStringValue:@"61412345678"];
-    options.shippingContact = shippingContact;
-    
-    options.merchantCapabilities = PKMerchantCapability3DS;
-    
-    PKContact *billingContact = [PKContact new];
-    NSPersonNameComponents *components = [NSPersonNameComponents new];
-    components.givenName = @"First";
-    components.familyName = @"Last";
-    
-    billingContact.name = components;
-    options.billingContact = billingContact;
-    
-    PKShippingMethod *method = [PKShippingMethod new];
-    method.identifier = @"identifier";
-    method.label = @"delivery";
-    method.amount = [[NSDecimalNumber alloc] initWithInt:10];
-    
-    options.shippingMethods = [NSArray arrayWithObject:method];
-    options.requiredShippingContactFields = [NSSet setWithObject:PKContactFieldName];
-    options.requiredBillingContactFields = [NSSet setWithObject:PKContactFieldPhoneNumber];
     
     PKPaymentRequest *request = [session makePaymentRequestOrError:nil];
     
@@ -62,18 +49,40 @@
     XCTAssertEqualObjects(request.paymentSummaryItems[0].label, options.totalPriceLabel);
     XCTAssertEqual(request.paymentSummaryItems[0].type, PKPaymentSummaryItemTypeFinal);
     
-    XCTAssertEqualObjects(request.merchantIdentifier, merchantIdentifier);
+    XCTAssertEqualObjects(request.merchantIdentifier, options.merchantIdentifier);
     XCTAssertEqual(request.merchantCapabilities, options.merchantCapabilities);
     XCTAssertEqualObjects(request.countryCode, session.countryCode);
     XCTAssertEqualObjects(request.currencyCode, intent.currency);
     XCTAssertEqualObjects(request.supportedNetworks, AWXApplePaySupportedNetworks());
-    XCTAssertEqualObjects(request.shippingContact, options.shippingContact);
-    XCTAssertEqual(request.shippingType, options.shippingType);
-    XCTAssertEqualObjects(request.shippingMethods, options.shippingMethods);
-    XCTAssertEqualObjects(request.billingContact, options.billingContact);
+    XCTAssertEqualObjects(request.billingContact, [session.billing convertToPaymentContact]);
     XCTAssertEqualObjects(request.requiredBillingContactFields, options.requiredBillingContactFields);
-    XCTAssertEqualObjects(request.requiredShippingContactFields, options.requiredShippingContactFields);
     XCTAssertEqualObjects(request.supportedCountries, options.supportedCountries);
+}
+
+- (void)testMakePaymentRequestWithCustomPaymentSummaryItems
+{
+    AWXOneOffSession *session = [AWXOneOffSession new];
+    session.countryCode = @"AU";
+    
+    AWXPaymentIntent *intent = [AWXPaymentIntent new];
+    session.paymentIntent = intent;
+    intent.currency = @"AUD";
+    intent.amount = [[NSDecimalNumber alloc] initWithInt:50];
+    
+    PKPaymentSummaryItem *subtotal = [PKPaymentSummaryItem summaryItemWithLabel:@"subtotal"
+                                                                         amount:[NSDecimalNumber decimalNumberWithMantissa:40 exponent:0 isNegative:NO]];
+    PKPaymentSummaryItem *tax = [PKPaymentSummaryItem summaryItemWithLabel:@"gst"
+                                                                    amount:[NSDecimalNumber decimalNumberWithMantissa:10 exponent:0 isNegative:NO]];
+    AWXApplePayOptions *options = [self makeOptions:@[subtotal, tax]];
+    session.applePayOptions = options;
+    
+    PKPaymentRequest *request = [session makePaymentRequestOrError:nil];
+    
+    XCTAssertEqual(request.paymentSummaryItems.count, 3);
+    XCTAssertEqualObjects(request.paymentSummaryItems[0], subtotal);
+    XCTAssertEqualObjects(request.paymentSummaryItems[1], tax);
+    XCTAssertEqualObjects(request.paymentSummaryItems[2].label, options.totalPriceLabel);
+    XCTAssertEqualObjects(request.paymentSummaryItems[2].amount, session.amount);
 }
 
 - (void)testMakePaymentRequestWithNoOptions
@@ -86,6 +95,43 @@
     
     XCTAssertNil(request);
     XCTAssertNotNil(error);
+}
+
+- (void)testMakePaymentRequestWithNoIntent
+{
+    AWXOneOffSession *session = [AWXOneOffSession new];
+    session.applePayOptions = [self makeOptions:nil];
+    session.paymentIntent = nil;
+    
+    NSError *error;
+    PKPaymentRequest *request = [session makePaymentRequestOrError:&error];
+    
+    XCTAssertNil(request);
+    XCTAssertNotNil(error);
+}
+
+- (AWXApplePayOptions *)makeOptions:(nullable NSArray <PKPaymentSummaryItem *> *)items
+{
+    AWXApplePayOptions *options = [[AWXApplePayOptions alloc] initWithMerchantIdentifier:@"merchantIdentifier"];
+    
+    options.additionalPaymentSummaryItems = items;
+    
+    options.supportedCountries = [NSSet setWithObjects:@"AU", @"US", nil];
+    options.totalPriceLabel = @"totalPrice";
+    
+    PKContact *shippingContact = [PKContact new];
+    shippingContact.phoneNumber = [[CNPhoneNumber alloc] initWithStringValue:@"61412345678"];
+    
+    options.merchantCapabilities = PKMerchantCapability3DS;
+    
+    PKShippingMethod *method = [PKShippingMethod new];
+    method.identifier = @"identifier";
+    method.label = @"delivery";
+    method.amount = [[NSDecimalNumber alloc] initWithInt:10];
+    
+    options.requiredBillingContactFields = [NSSet setWithObject:PKContactFieldPhoneNumber];
+    
+    return options;
 }
 
 @end

--- a/Airwallex/ApplePayTests/AWXPaymentIntentSummaryTest.m
+++ b/Airwallex/ApplePayTests/AWXPaymentIntentSummaryTest.m
@@ -23,11 +23,7 @@
     
     NSString *label = @"label";
     
-    NSArray <PKPaymentSummaryItem *> *items = [intent paymentSummaryItemsWithTotalPriceLabel:label];
-    
-    XCTAssertEqual(items.count, 1);
-    
-    PKPaymentSummaryItem *item = items[0];
+    PKPaymentSummaryItem *item = [intent paymentSummaryItemWithTotalPriceLabel:label];
     
     XCTAssertEqualObjects(item.label, label);
     XCTAssertEqual(item.type, PKPaymentSummaryItemTypeFinal);
@@ -39,11 +35,7 @@
     AWXPaymentIntent *intent = [AWXPaymentIntent new];
     intent.amount = [[NSDecimalNumber alloc] initWithString:@"1234.5"];
     
-    NSArray <PKPaymentSummaryItem *> *items = [intent paymentSummaryItemsWithTotalPriceLabel:nil];
-    
-    XCTAssertEqual(items.count, 1);
-    
-    PKPaymentSummaryItem *item = items[0];
+    PKPaymentSummaryItem *item = [intent paymentSummaryItemWithTotalPriceLabel:nil];
     
     XCTAssertEqualObjects(item.label, @"");
 }

--- a/Airwallex/ApplePayTests/AWXPlaceDetailsPKContactTest.m
+++ b/Airwallex/ApplePayTests/AWXPlaceDetailsPKContactTest.m
@@ -27,18 +27,20 @@
     address.countryCode = @"AU";
     address.city = @"Melbourne";
     address.street = @"Name St.";
+    address.state = @"VIC";
+    address.postcode = @"3000";
     
     details.address = address;
     
     PKContact *contact = [details convertToPaymentContact];
     
-    XCTAssertEqual(contact.name.givenName, details.firstName);
-    XCTAssertEqual(contact.name.familyName, details.lastName);
-    XCTAssertEqual(contact.postalAddress.ISOCountryCode, address.countryCode);
-    XCTAssertEqual(contact.postalAddress.city, address.city);
-    XCTAssertEqual(contact.postalAddress.street, address.street);
-    XCTAssertEqualObjects(contact.postalAddress.state, @"");
-    XCTAssertEqualObjects(contact.postalAddress.postalCode, @"");
+    XCTAssertEqual(contact.name.givenName, @"firstName");
+    XCTAssertEqual(contact.name.familyName, @"lastName");
+    XCTAssertEqual(contact.postalAddress.ISOCountryCode, @"AU");
+    XCTAssertEqual(contact.postalAddress.city, @"Melbourne");
+    XCTAssertEqual(contact.postalAddress.street, @"Name St.");
+    XCTAssertEqualObjects(contact.postalAddress.state, @"VIC");
+    XCTAssertEqualObjects(contact.postalAddress.postalCode, @"3000");
     XCTAssertNil(contact.emailAddress);
     XCTAssertNil(contact.phoneNumber);
 }

--- a/Airwallex/ApplePayTests/AWXPlaceDetailsPKContactTest.m
+++ b/Airwallex/ApplePayTests/AWXPlaceDetailsPKContactTest.m
@@ -1,0 +1,46 @@
+//
+//  AWXPlaceDetailsPKContactTest.m
+//  ApplePayTests
+//
+//  Created by Jin Wang on 13/4/2022.
+//  Copyright © 2022 Airwallex. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "AWXPlaceDetails+PKContact.h"
+
+@interface AWXPlaceDetailsPKContactTest : XCTestCase
+
+@end
+
+@implementation AWXPlaceDetailsPKContactTest
+
+- (void)testConvertToPaymentContact {
+    AWXPlaceDetails *details = [AWXPlaceDetails new];
+    details.firstName = @"firstName";
+    details.lastName = @"lastName";
+    
+    details.email = nil;
+    details.phoneNumber = nil;
+    
+    AWXAddress *address = [AWXAddress new];
+    address.countryCode = @"AU";
+    address.city = @"Melbourne";
+    address.street = @"Name St.";
+    
+    details.address = address;
+    
+    PKContact *contact = [details convertToPaymentContact];
+    
+    XCTAssertEqual(contact.name.givenName, details.firstName);
+    XCTAssertEqual(contact.name.familyName, details.lastName);
+    XCTAssertEqual(contact.postalAddress.ISOCountryCode, address.countryCode);
+    XCTAssertEqual(contact.postalAddress.city, address.city);
+    XCTAssertEqual(contact.postalAddress.street, address.street);
+    XCTAssertEqualObjects(contact.postalAddress.state, @"");
+    XCTAssertEqualObjects(contact.postalAddress.postalCode, @"");
+    XCTAssertNil(contact.emailAddress);
+    XCTAssertNil(contact.phoneNumber);
+}
+
+@end

--- a/Airwallex/ApplePayTests/PKContactRequestTest.m
+++ b/Airwallex/ApplePayTests/PKContactRequestTest.m
@@ -1,0 +1,96 @@
+//
+//  PKContactRequestTest.m
+//  ApplePayTests
+//
+//  Created by Jin Wang on 13/4/2022.
+//  Copyright © 2022 Airwallex. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <PassKit/PassKit.h>
+#import "PKContact+Request.h"
+
+@interface PKContactRequestTest : XCTestCase
+
+@end
+
+@implementation PKContactRequestTest
+
+- (void)testPayloadForRequest {
+    PKContact *contact = [PKContact new];
+    contact.emailAddress = @"email@address.com";
+    
+    NSPersonNameComponents *nameComponents = [NSPersonNameComponents new];
+    nameComponents.givenName = @"firstName";
+    nameComponents.familyName = @"lastName";
+    contact.name = nameComponents;
+    contact.phoneNumber = [CNPhoneNumber phoneNumberWithStringValue:@"12345678"];
+    
+    CNMutablePostalAddress *address = [CNMutablePostalAddress new];
+    address.ISOCountryCode = @"AU";
+    address.city = @"Melbourne";
+    address.postalCode = @"3008";
+    address.state = @"VIC";
+    address.street = @"Name St.";
+    
+    contact.postalAddress = address;
+    
+    NSDictionary *payload = [contact payloadForRequest];
+    NSDictionary *expected = @{
+        @"email": @"email@address.com",
+        @"first_name": @"firstName",
+        @"last_name": @"lastName",
+        @"phone_number": @"12345678",
+        @"address": @{
+            @"country_code": @"AU",
+            @"city": @"Melbourne",
+            @"postcode": @"3008",
+            @"state": @"VIC",
+            @"street": @"Name St."
+        }
+    };
+    
+    XCTAssertEqualObjects(payload, expected);
+}
+
+- (void)testPayloadForRequestWithPartialNilValues {
+    PKContact *contact = [PKContact new];
+    
+    NSPersonNameComponents *nameComponents = [NSPersonNameComponents new];
+    nameComponents.givenName = nil;
+    nameComponents.familyName = @"lastName";
+    contact.name = nameComponents;
+    
+    CNMutablePostalAddress *address = [CNMutablePostalAddress new];
+    address.ISOCountryCode = @"";
+    address.city = @"";
+    address.postalCode = @"";
+    address.state = @"";
+    address.street = @"";
+    
+    contact.postalAddress = address;
+    
+    NSDictionary *payload = [contact payloadForRequest];
+    NSDictionary *expected = @{
+        @"last_name": @"lastName",
+        @"address": @{
+            @"country_code": @"",
+            @"city": @"",
+            @"postcode": @"",
+            @"state": @"",
+            @"street": @""
+        }
+    };
+    
+    XCTAssertEqualObjects(payload, expected);
+}
+
+- (void)testPayloadForRequestWithAllNilValues {
+    PKContact *contact = [PKContact new];
+    NSDictionary *payload = [contact payloadForRequest];
+    NSDictionary *expected = @{};
+    
+    XCTAssertEqualObjects(payload, expected);
+}
+
+@end

--- a/Airwallex/ApplePayTests/PKPaymentTokenRequestTest.m
+++ b/Airwallex/ApplePayTests/PKPaymentTokenRequestTest.m
@@ -53,7 +53,7 @@
     OCMStub([method network]).andReturn(network);
     OCMStub([method typeNameForRequest]).andReturn(type);
     
-    NSDictionary *payload = [token payloadForRequestOrError:nil];
+    NSDictionary *payload = [token payloadForRequestWithBilling:nil orError:nil];
     
     NSDictionary *expectedPayload = @{
         @"card_brand": network,
@@ -67,6 +67,14 @@
     };
     
     XCTAssertEqualObjects(payload, expectedPayload);
+    
+    NSDictionary *billingPayload = @{@"key": @"value"};
+    NSDictionary *payloadWithBilling = [token payloadForRequestWithBilling:billingPayload orError:nil];
+    
+    NSMutableDictionary *expectedPayloadWithBilling = [NSMutableDictionary dictionaryWithDictionary:expectedPayload];
+    expectedPayloadWithBilling[@"billing"] = billingPayload;
+    
+    XCTAssertEqualObjects(payloadWithBilling, expectedPayloadWithBilling);
 }
 
 - (void)testPayloadForRequestWithError
@@ -78,7 +86,7 @@
     OCMStub([tokenMock paymentData]).andReturn(paymentData);
     
     NSError *error;
-    NSDictionary *payload = [token payloadForRequestOrError:&error];
+    NSDictionary *payload = [token payloadForRequestWithBilling:nil orError:&error];
     
     XCTAssertNil(payload);
     XCTAssertNotNil(error);

--- a/Airwallex/Core/Sources/AWXApplePayOptions.h
+++ b/Airwallex/Core/Sources/AWXApplePayOptions.h
@@ -11,6 +11,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ Object used to construct PKPaymentRequest for Apple Pay.
+ */
 @interface AWXApplePayOptions : NSObject
 
 /**
@@ -19,14 +22,18 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) NSString *merchantIdentifier;
 
 /**
+ An additional array of payment summary item objects that summarize the amount of the payment. Default value is nil.
+ 
+ The SDK will automatically construct a PKPaymentSummaryItem with the total amount from the session object and
+ the label defined with the totalPriceLabel property. Please make sure the sum of all the items in the array equals the total amount
+ you set on the session object.
+ */
+@property (nonatomic, copy, nullable) NSArray <PKPaymentSummaryItem *> *additionalPaymentSummaryItems;
+
+/**
  Apple Pay merchant capabilities. Default value includes 3DS, EMV, Credit and Debit.
  */
 @property (nonatomic, assign) PKMerchantCapability merchantCapabilities;
-
-/**
- How the item are to be shipped. Default value is PKShippingTypeShipping.
- */
-@property (nonatomic, assign) PKShippingType shippingType;
 
 /**
  The billing information that you require from the user in order to process the transaction. Default value is empty set.
@@ -34,34 +41,14 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) NSSet <PKContactField> *requiredBillingContactFields;
 
 /**
- The shipping information that you require from the user in order to fulfill the order. Default value is empty set.
- */
-@property (nonatomic, strong) NSSet <PKContactField> *requiredShippingContactFields;
-
-/**
- Description of the total price. Default value is nil.
- */
-@property (nonatomic, copy, nullable) NSString *totalPriceLabel;
-
-/**
  A list of ISO 3166 country codes for limiting payments to cards from specific countries. Default value is null, meaning all countries are allowed.
  */
 @property (nonatomic, copy, nullable) NSSet <NSString *> *supportedCountries;
 
 /**
- A set of shipping method objects that describe the available shipping methods. Default value is nil.
+ Description of the total price. Default value is nil.
  */
-@property (nonatomic, strong, nullable) NSArray <PKShippingMethod *> *shippingMethods;
-
-/**
- Shipping contact information for the user. Default value is nil.
- */
-@property (nonatomic, strong, nullable) PKContact *shippingContact;
-
-/**
- Billing contact information for the user. Default value is nil.
- */
-@property (nonatomic, strong, nullable) PKContact *billingContact;
+@property (nonatomic, copy, nullable) NSString *totalPriceLabel;
 
 - (instancetype)initWithMerchantIdentifier:(NSString *)merchantIdentifier;
 

--- a/Airwallex/Core/Sources/AWXApplePayOptions.m
+++ b/Airwallex/Core/Sources/AWXApplePayOptions.m
@@ -17,9 +17,7 @@
     if (self) {
         _merchantIdentifier = merchantIdentifier;
         _merchantCapabilities = PKMerchantCapability3DS | PKMerchantCapabilityEMV | PKMerchantCapabilityDebit | PKMerchantCapabilityCredit;
-        _shippingType = PKShippingTypeShipping;
         _requiredBillingContactFields = [NSSet new];
-        _requiredShippingContactFields = [NSSet new];
     }
     return self;
 }

--- a/Airwallex/CoreTests/AWXApplePayOptionsTest.m
+++ b/Airwallex/CoreTests/AWXApplePayOptionsTest.m
@@ -21,14 +21,10 @@
     AWXApplePayOptions *options = [[AWXApplePayOptions alloc] initWithMerchantIdentifier:identifier];
     
     XCTAssertEqualObjects(options.merchantIdentifier, identifier);
-    XCTAssertEqual(options.shippingType, PKShippingTypeShipping);
     XCTAssertEqualObjects(options.requiredBillingContactFields, [NSSet new]);
-    XCTAssertEqualObjects(options.requiredShippingContactFields, [NSSet new]);
     XCTAssertNil(options.totalPriceLabel);
     XCTAssertNil(options.supportedCountries);
-    XCTAssertNil(options.shippingMethods);
-    XCTAssertNil(options.shippingContact);
-    XCTAssertNil(options.billingContact);
+    XCTAssertNil(options.additionalPaymentSummaryItems);
 }
 
 @end

--- a/Examples/Examples/Cart/CartViewController.m
+++ b/Examples/Examples/Cart/CartViewController.m
@@ -278,6 +278,8 @@
             AWXOneOffSession *session = [AWXOneOffSession new];
             
             AWXApplePayOptions *options = [[AWXApplePayOptions alloc] initWithMerchantIdentifier:@"merchant.com.airwallex.checkout"];
+            options.requiredBillingContactFields = [NSSet setWithObjects:PKContactFieldName, PKContactFieldPostalAddress, nil];
+            
             session.applePayOptions = options;
             
             session.countryCode = [AirwallexExamplesKeys shared].countryCode;


### PR DESCRIPTION
This PR 
- added a new field on `AWXApplePayOptions` class to allow merchants to provide additional payment summary items  to be shown to the customers.
- removed shipping related options from `AWXApplePayOptions`. We don't support editing shipping information on the Apple Pay prompt.
- handled billing edit and sent billing information to the API when confirming the payment intent. See attached demo.

https://user-images.githubusercontent.com/73088020/163294994-bcdae274-5497-4fd5-ab0a-b59d83d1113e.mov


