### PR TITLE
fix: added a flow parameter when requesting payment method types

### DIFF
--- a/Airwallex/Core/Sources/Internal/AWXPaymentMethodRequest.h
+++ b/Airwallex/Core/Sources/Internal/AWXPaymentMethodRequest.h
@@ -97,6 +97,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, copy, nullable) NSString *lang;
 
+/**
+ Filter payment methods for a specific flow. Defaults to inapp.
+ */
+@property (nonatomic, copy, nullable) NSString *flow;
+
 @end
 
 /**

--- a/Airwallex/Core/Sources/Internal/AWXPaymentMethodRequest.m
+++ b/Airwallex/Core/Sources/Internal/AWXPaymentMethodRequest.m
@@ -71,6 +71,7 @@
         self.pageNum = 0;
         self.pageSize = 10;
         self.resources = YES;
+        self.flow = @"inapp";
     }
     return self;
 }
@@ -106,6 +107,9 @@
     }
     if (self.lang) {
         _parameters[@"lang"] = self.lang;
+    }
+    if (self.flow) {
+        _parameters[@"flow"] = self.flow;
     }
     return _parameters;
 }

--- a/Airwallex/CoreTests/API/AWXPaymentMethodFunctionalTest.m
+++ b/Airwallex/CoreTests/API/AWXPaymentMethodFunctionalTest.m
@@ -35,6 +35,8 @@
     request.active = YES;
     request.pageNum = 0;
     request.transactionCurrency = @"HKD";
+    
+    XCTAssertEqualObjects(request.flow, @"inapp");
 
     AWXAPIClient *client = [AWXAPIClient sharedClient];
     XCTestExpectation *expectation = [self expectationWithDescription:@"Get payment method list"];


### PR DESCRIPTION
This PR added a flow parameter to the queries when requesting payment method types for the payment method sheet. This will help filter out Apple Pay when it's only configured for web domains.