### PR TITLE
[MOB-1009] Save card in one-off payment session

### DIFF
--- a/Airwallex/Airwallex.xcodeproj/project.pbxproj
+++ b/Airwallex/Airwallex.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		1803601B2873C878003EA943 /* AWXPaymentFormViewModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 1803601A2873C878003EA943 /* AWXPaymentFormViewModel.h */; };
 		1803601D2873CAE2003EA943 /* AWXPaymentFormViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 1803601C2873CAE2003EA943 /* AWXPaymentFormViewModel.m */; };
 		1803601F2873D73A003EA943 /* AWXPaymentFormViewModelTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1803601E2873D73A003EA943 /* AWXPaymentFormViewModelTest.m */; };
+		187AFA6928B522C000561EEB /* AWXPaymentConsentRequestTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 187AFA6828B522C000561EEB /* AWXPaymentConsentRequestTest.m */; };
 		2B622DDF0972633197AAC8DB /* Pods_CoreTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F087D6C1F1A19092F78A54AB /* Pods_CoreTests.framework */; };
 		3C2B649227E98858002FAF3E /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C2B649127E98858002FAF3E /* AppDelegate.m */; };
 		3C2B649827E98858002FAF3E /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C2B649727E98858002FAF3E /* ViewController.m */; };
@@ -325,6 +326,7 @@
 		1803601A2873C878003EA943 /* AWXPaymentFormViewModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AWXPaymentFormViewModel.h; sourceTree = "<group>"; };
 		1803601C2873CAE2003EA943 /* AWXPaymentFormViewModel.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWXPaymentFormViewModel.m; sourceTree = "<group>"; };
 		1803601E2873D73A003EA943 /* AWXPaymentFormViewModelTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWXPaymentFormViewModelTest.m; sourceTree = "<group>"; };
+		187AFA6828B522C000561EEB /* AWXPaymentConsentRequestTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWXPaymentConsentRequestTest.m; sourceTree = "<group>"; };
 		3C2B648E27E98858002FAF3E /* TestHost.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestHost.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3C2B649027E98858002FAF3E /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		3C2B649127E98858002FAF3E /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -643,6 +645,7 @@
 			children = (
 				0829FD122431E11E00557DB2 /* AWXPaymentMethodFunctionalTest.m */,
 				0829FD142431F13A00557DB2 /* AWXPaymentIntentFunctionalTest.m */,
+				187AFA6828B522C000561EEB /* AWXPaymentConsentRequestTest.m */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -1716,6 +1719,7 @@
 				0829FD022431D10800557DB2 /* AWXAddressTest.m in Sources */,
 				3C324F9327FC0BF200CF7315 /* AWXSessionInternalTest.m in Sources */,
 				3C99E73F27E9A3380074156C /* AWXDefaultProviderTest.m in Sources */,
+				187AFA6928B522C000561EEB /* AWXPaymentConsentRequestTest.m in Sources */,
 				082442CC2431C00E00D04A2C /* AWXCardTest.m in Sources */,
 				3C324F9527FC108500CF7315 /* AWXConstantsInternalTest.m in Sources */,
 				572D1BEE26DF4D06001EBDAA /* AWXSessionTest.m in Sources */,

--- a/Airwallex/Card/AWXCardProvider.h
+++ b/Airwallex/Card/AWXCardProvider.h
@@ -22,7 +22,8 @@ NS_ASSUME_NONNULL_BEGIN
  @param billing The billing info.
  */
 - (void)confirmPaymentIntentWithCard:(AWXCard *)card
-                             billing:(AWXPlaceDetails *)billing;
+                             billing:(AWXPlaceDetails *)billing
+                            saveCard:(BOOL)saveCard;
 
 @end
 

--- a/Airwallex/Card/AWXCardProvider.m
+++ b/Airwallex/Card/AWXCardProvider.m
@@ -58,31 +58,30 @@
 
 - (void)confirmPaymentIntentWithPaymentMethod:(AWXPaymentMethod *)paymentMethod {
     __weak __typeof(self) weakSelf = self;
-    [[AWXSecurityService sharedService] doProfile:self.session.paymentIntentId
-                                       completion:^(NSString *_Nullable sessionId) {
-                                           __strong __typeof(weakSelf) strongSelf = weakSelf;
-
-                                           AWXDevice *device = [AWXDevice new];
-                                           device.deviceId = sessionId;
-
-                                           [strongSelf confirmPaymentIntentWithPaymentMethod:paymentMethod paymentConsent:nil device:device];
-                                       }];
+    [self setDevice:^(AWXDevice * _Nonnull device) {
+        __strong __typeof(weakSelf) strongSelf = weakSelf;
+        [strongSelf confirmPaymentIntentWithPaymentMethod:paymentMethod paymentConsent:nil device:device];
+    }];
 }
 
 - (void)createPaymentConsentAndConfirmIntentWithPaymentMethod:(AWXPaymentMethod *)paymentMethod {
     __weak __typeof(self) weakSelf = self;
-    [[AWXSecurityService sharedService] doProfile:self.session.paymentIntentId
-                                       completion:^(NSString *_Nullable sessionId) {
-                                           __strong __typeof(weakSelf) strongSelf = weakSelf;
-
-                                           AWXDevice *device = [AWXDevice new];
-                                           device.deviceId = sessionId;
-
-                                           [strongSelf createPaymentConsentAndConfirmIntentWithPaymentMethod:paymentMethod device:device];
-                                       }];
+    [self setDevice:^(AWXDevice * _Nonnull device) {
+        __strong __typeof(weakSelf) strongSelf = weakSelf;
+        [strongSelf createPaymentConsentAndConfirmIntentWithPaymentMethod:paymentMethod device:device];
+    }];
 }
 
 #pragma mark - Internal Actions
+
+- (void)setDevice:(void (^)(AWXDevice *_Nonnull))completion {
+    [[AWXSecurityService sharedService] doProfile:self.session.paymentIntentId
+                                       completion:^(NSString *_Nullable sessionId) {
+        AWXDevice *device = [AWXDevice new];
+        device.deviceId = sessionId;
+        completion(device);
+    }];
+}
 
 - (void)createPaymentMethod:(AWXPaymentMethod *)paymentMethod
                  completion:(AWXRequestHandler)completion {

--- a/Airwallex/Card/AWXCardProvider.m
+++ b/Airwallex/Card/AWXCardProvider.m
@@ -27,7 +27,8 @@
 }
 
 - (void)confirmPaymentIntentWithCard:(AWXCard *)card
-                             billing:(AWXPlaceDetails *)billing {
+                             billing:(AWXPlaceDetails *)billing
+                            saveCard:(BOOL)saveCard {
     AWXPaymentMethod *paymentMethod = [AWXPaymentMethod new];
     paymentMethod.type = AWXCardKey;
     paymentMethod.billing = billing;
@@ -35,7 +36,7 @@
     paymentMethod.customerId = self.session.customerId;
 
     [self.delegate providerDidStartRequest:self];
-    if ([self.session isKindOfClass:[AWXOneOffSession class]]) {
+    if ([self.session isKindOfClass:[AWXOneOffSession class]] && !saveCard) {
         [self confirmPaymentIntentWithPaymentMethod:paymentMethod];
     } else {
         __weak __typeof(self) weakSelf = self;
@@ -46,7 +47,7 @@
                                AWXCreatePaymentMethodResponse *result = (AWXCreatePaymentMethodResponse *)response;
                                AWXPaymentMethod *paymentMethod = result.paymentMethod;
                                paymentMethod.card.cvc = card.cvc;
-                               [strongSelf confirmPaymentIntentWithPaymentMethod:paymentMethod];
+                               [strongSelf createPaymentConsentAndConfirmIntentWithPaymentMethod:paymentMethod];
                            } else {
                                [strongSelf.delegate providerDidEndRequest:strongSelf];
                                [strongSelf.delegate provider:strongSelf didCompleteWithStatus:AirwallexPaymentStatusFailure error:error];
@@ -65,6 +66,19 @@
                                            device.deviceId = sessionId;
 
                                            [strongSelf confirmPaymentIntentWithPaymentMethod:paymentMethod paymentConsent:nil device:device];
+                                       }];
+}
+
+- (void)createPaymentConsentAndConfirmIntentWithPaymentMethod:(AWXPaymentMethod *)paymentMethod {
+    __weak __typeof(self) weakSelf = self;
+    [[AWXSecurityService sharedService] doProfile:self.session.paymentIntentId
+                                       completion:^(NSString *_Nullable sessionId) {
+                                           __strong __typeof(weakSelf) strongSelf = weakSelf;
+
+                                           AWXDevice *device = [AWXDevice new];
+                                           device.deviceId = sessionId;
+
+                                           [strongSelf createPaymentConsentAndConfirmIntentWithPaymentMethod:paymentMethod device:device];
                                        }];
 }
 

--- a/Airwallex/Card/Internal/AWXCardViewController.m
+++ b/Airwallex/Card/Internal/AWXCardViewController.m
@@ -298,7 +298,7 @@ typedef enum {
 }
 
 - (void)saveCardSwitchChanged:(id)sender {
-    self.saveCard = !self.saveCard;
+    self.saveCard = [(UISwitch *)sender isOn];
 }
 
 - (void)addressSwitchChanged:(id)sender {

--- a/Airwallex/Card/Internal/AWXCardViewController.m
+++ b/Airwallex/Card/Internal/AWXCardViewController.m
@@ -35,7 +35,7 @@
 @property (strong, nonatomic) AWXFloatingLabelTextField *nameField;
 @property (strong, nonatomic) AWXFloatingLabelTextField *expiresField;
 @property (strong, nonatomic) AWXFloatingLabelTextField *cvcField;
-@property (strong, nonatomic) UISwitch *switchButton;
+@property (strong, nonatomic) UISwitch *addressSwitch;
 @property (strong, nonatomic) AWXFloatingLabelTextField *firstNameField;
 @property (strong, nonatomic) AWXFloatingLabelTextField *lastNameField;
 @property (strong, nonatomic) AWXFloatingLabelView *countryView;
@@ -49,10 +49,16 @@
 
 @property (strong, nonatomic, nullable) AWXCountry *country;
 @property (strong, nonatomic, nullable) AWXPlaceDetails *savedBilling;
+@property (nonatomic) BOOL saveCard;
 
 @end
 
 @implementation AWXCardViewController
+
+typedef enum {
+    AddressSwitch,
+    SaveCardSwitch
+} SwitchType;
 
 - (void)viewDidLoad {
     [super viewDidLoad];
@@ -124,29 +130,17 @@
     [cvcStackView addArrangedSubview:_cvcField];
     [_expiresField.widthAnchor constraintEqualToAnchor:_cvcField.widthAnchor multiplier:1.7].active = YES;
 
+    if ([self.session isKindOfClass:[AWXOneOffSession class]] && self.session.customerId) {
+        [stackView addArrangedSubview:[self switchOfType:SaveCardSwitch]];
+    }
+
     UILabel *billingLabel = [UILabel new];
     billingLabel.text = NSLocalizedString(@"Billing info", @"Billing info");
     billingLabel.textColor = [AWXTheme sharedTheme].primaryTextColor;
     billingLabel.font = [UIFont subhead2Font];
     [stackView addArrangedSubview:billingLabel];
 
-    UIStackView *shippingStackView = [UIStackView new];
-    shippingStackView.axis = UILayoutConstraintAxisHorizontal;
-    shippingStackView.alignment = UIStackViewAlignmentFill;
-    shippingStackView.distribution = UIStackViewDistributionFill;
-    shippingStackView.spacing = 23;
-    shippingStackView.translatesAutoresizingMaskIntoConstraints = NO;
-    [stackView addArrangedSubview:shippingStackView];
-
-    UILabel *shippingLabel = [UILabel new];
-    shippingLabel.text = NSLocalizedString(@"Same as shipping address", @"Same as shipping address");
-    shippingLabel.textColor = [AWXTheme sharedTheme].secondaryTextColor;
-    shippingLabel.font = [UIFont subhead1Font];
-    [shippingStackView addArrangedSubview:shippingLabel];
-
-    _switchButton = [UISwitch new];
-    [_switchButton addTarget:self action:@selector(switchChanged:) forControlEvents:UIControlEventValueChanged];
-    [shippingStackView addArrangedSubview:_switchButton];
+    [stackView addArrangedSubview:[self switchOfType:AddressSwitch]];
 
     _firstNameField = [AWXFloatingLabelTextField new];
     _firstNameField.fieldType = AWXTextFieldTypeFirstName;
@@ -234,7 +228,36 @@
         }
     }
     self.sameAsShipping = self.session.billing != nil;
-    _switchButton.on = self.sameAsShipping;
+    _addressSwitch.on = self.sameAsShipping;
+    self.saveCard = false;
+}
+
+- (UIStackView *)switchOfType:(SwitchType)type {
+    UIStackView *container = [UIStackView new];
+    container.axis = UILayoutConstraintAxisHorizontal;
+    container.alignment = UIStackViewAlignmentFill;
+    container.distribution = UIStackViewDistributionFill;
+    container.spacing = 23;
+    container.translatesAutoresizingMaskIntoConstraints = NO;
+
+    UISwitch *switchButton = [UISwitch new];
+    UILabel *titleLabel = [UILabel new];
+    switch (type) {
+    case AddressSwitch:
+        titleLabel.text = NSLocalizedString(@"Same as shipping address", @"Same as shipping address");
+        self.addressSwitch = switchButton;
+        [switchButton addTarget:self action:@selector(addressSwitchChanged:) forControlEvents:UIControlEventValueChanged];
+        break;
+    case SaveCardSwitch:
+        titleLabel.text = NSLocalizedString(@"Save this card for future payments", @"Save this card for future payments");
+        [switchButton addTarget:self action:@selector(saveCardSwitchChanged:) forControlEvents:UIControlEventValueChanged];
+        break;
+    }
+    titleLabel.textColor = [AWXTheme sharedTheme].secondaryTextColor;
+    titleLabel.font = [UIFont subhead1Font];
+    [container addArrangedSubview:titleLabel];
+    [container addArrangedSubview:switchButton];
+    return container;
 }
 
 - (UIScrollView *)activeScrollView {
@@ -274,7 +297,11 @@
     _phoneNumberField.hidden = sameAsShipping;
 }
 
-- (void)switchChanged:(id)sender {
+- (void)saveCardSwitchChanged:(id)sender {
+    self.saveCard = !self.saveCard;
+}
+
+- (void)addressSwitchChanged:(id)sender {
     if (!self.session.billing) {
         UIAlertController *controller = [UIAlertController alertControllerWithTitle:nil
                                                                             message:NSLocalizedString(@"No shipping address configured.", nil)
@@ -282,13 +309,13 @@
         [controller addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Close", nil)
                                                        style:UIAlertActionStyleCancel
                                                      handler:^(UIAlertAction *_Nonnull action) {
-                                                         self.switchButton.on = NO;
+                                                         self.addressSwitch.on = NO;
                                                      }]];
         [self presentViewController:controller animated:YES completion:nil];
         return;
     }
 
-    self.sameAsShipping = self.switchButton.isOn;
+    self.sameAsShipping = self.addressSwitch.isOn;
 }
 
 - (void)selectCountries:(id)sender {
@@ -343,7 +370,7 @@
     }
 
     AWXCardProvider *provider = [[AWXCardProvider alloc] initWithDelegate:self session:self.session];
-    [provider confirmPaymentIntentWithCard:card billing:self.savedBilling];
+    [provider confirmPaymentIntentWithCard:card billing:self.savedBilling saveCard:self.saveCard];
     self.provider = provider;
 }
 

--- a/Airwallex/Core/Sources/AWXConstants.h
+++ b/Airwallex/Core/Sources/AWXConstants.h
@@ -36,6 +36,7 @@ typedef NS_ENUM(NSUInteger, AirwallexNextTriggerByType) {
 };
 
 typedef NS_ENUM(NSUInteger, AirwallexMerchantTriggerReason) {
+    AirwallexMerchantTriggerReasonUndefined,
     AirwallexMerchantTriggerReasonUnscheduled,
     AirwallexMerchantTriggerReasonScheduled
 };

--- a/Airwallex/Core/Sources/AWXConstants.m
+++ b/Airwallex/Core/Sources/AWXConstants.m
@@ -79,6 +79,8 @@ AWXTextFieldType GetTextFieldTypeByUIType(NSString *uiType) {
 
 NSString *FormatMerchantTriggerReason(AirwallexMerchantTriggerReason reason) {
     switch (reason) {
+    case AirwallexMerchantTriggerReasonUndefined:
+        return NULL;
     case AirwallexMerchantTriggerReasonUnscheduled:
         return @"unscheduled";
     case AirwallexMerchantTriggerReasonScheduled:

--- a/Airwallex/Core/Sources/AWXDefaultProvider.h
+++ b/Airwallex/Core/Sources/AWXDefaultProvider.h
@@ -115,6 +115,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)handleFlow;
 
 /**
+ Create a new payment consent and confirm the payment intent with payment method.
+
+ @param paymentMethod The payment method info.
+ @param device The current device info.
+ */
+- (void)createPaymentConsentAndConfirmIntentWithPaymentMethod:(AWXPaymentMethod *)paymentMethod
+                                                       device:(nullable AWXDevice *)device;
+
+/**
  Confirm the payment intent with payment method and consent.
 
  @param paymentMethod The payment method info.

--- a/Airwallex/Core/Sources/AWXDefaultProvider.m
+++ b/Airwallex/Core/Sources/AWXDefaultProvider.m
@@ -239,15 +239,15 @@
                                              if (strongSelf.paymentConsent && [paymentMethod.type isEqualToString:AWXCardKey]) {
                                                  returnURL = AWXThreeDSReturnURL;
                                              }
-                                             AWXOneOffSession *session = (AWXOneOffSession *)self.session;
-                                             [self confirmPaymentIntentWithId:session.paymentIntent.Id
-                                                                   customerId:session.paymentIntent.customerId
-                                                                paymentMethod:paymentMethod
-                                                               paymentConsent:strongSelf.paymentConsent
-                                                                       device:device
-                                                                    returnURL:returnURL
-                                                                  autoCapture:session.autoCapture
-                                                                   completion:completion];
+                                             AWXOneOffSession *session = (AWXOneOffSession *)strongSelf.session;
+                                             [strongSelf confirmPaymentIntentWithId:session.paymentIntent.Id
+                                                                         customerId:session.paymentIntent.customerId
+                                                                      paymentMethod:paymentMethod
+                                                                     paymentConsent:strongSelf.paymentConsent
+                                                                             device:device
+                                                                          returnURL:returnURL
+                                                                        autoCapture:session.autoCapture
+                                                                         completion:completion];
                                          }];
     } else if ([self.session isKindOfClass:[AWXRecurringSession class]]) {
         AWXRecurringSession *session = (AWXRecurringSession *)self.session;
@@ -265,6 +265,7 @@
                                                  if (strongSelf.paymentConsent && [paymentMethod.type isEqualToString:AWXCardKey]) {
                                                      returnURL = AWXThreeDSReturnURL;
                                                  }
+                                                 AWXRecurringSession *session = (AWXRecurringSession *)strongSelf.session;
                                                  [strongSelf verifyPaymentConsentWithPaymentMethod:paymentMethod
                                                                                     paymentConsent:strongSelf.paymentConsent
                                                                                           currency:session.currency
@@ -286,6 +287,7 @@
                               merchantTriggerReason:session.merchantTriggerReason
                                          completion:^(AWXResponse *_Nullable response, NSError *_Nullable error) {
                                              __strong __typeof(weakSelf) strongSelf = weakSelf;
+                                             AWXRecurringWithIntentSession *session = (AWXRecurringWithIntentSession *)self.session;
                                              if ([paymentMethod.type isEqualToString:AWXCardKey]) {
                                                  [strongSelf confirmPaymentIntentWithId:session.paymentIntent.Id
                                                                              customerId:session.paymentIntent.customerId

--- a/Airwallex/Core/Sources/AWXDefaultProvider.m
+++ b/Airwallex/Core/Sources/AWXDefaultProvider.m
@@ -51,6 +51,18 @@
     [self confirmPaymentIntentWithPaymentMethod:_paymentMethod paymentConsent:nil device:nil];
 }
 
+- (void)createPaymentConsentAndConfirmIntentWithPaymentMethod:(AWXPaymentMethod *)paymentMethod
+                                                       device:(nullable AWXDevice *)device {
+    [self.delegate providerDidStartRequest:self];
+    __weak __typeof(self) weakSelf = self;
+    [self createPaymentConsentAndConfirmIntentWithPaymentMethod:[self paymentMethodWithMetaData:paymentMethod]
+                                                         device:device
+                                                     completion:^(AWXResponse *_Nullable response, NSError *_Nullable error) {
+                                                         __strong __typeof(weakSelf) strongSelf = weakSelf;
+                                                         [strongSelf completeWithResponse:(AWXConfirmPaymentIntentResponse *)response error:error];
+                                                     }];
+}
+
 - (void)confirmPaymentIntentWithPaymentMethod:(AWXPaymentMethod *)paymentMethod
                                paymentConsent:(nullable AWXPaymentConsent *)paymentConsent
                                        device:(nullable AWXDevice *)device {
@@ -70,19 +82,8 @@
                                    completion:(AWXRequestHandler)completion {
     self.paymentConsent = paymentConsent;
 
-    if (![paymentMethod.type isEqualToString:AWXCardKey]) {
-        NSDictionary *metaData = @{@"flow": @"inapp", @"os_type": @"ios"};
-        if (paymentMethod.additionalParams) {
-            NSMutableDictionary *params = paymentMethod.additionalParams.mutableCopy;
-            [params addEntriesFromDictionary:metaData];
-            paymentMethod.additionalParams = params;
-        } else {
-            paymentMethod.additionalParams = metaData;
-        }
-    }
-
     [self.delegate providerDidStartRequest:self];
-    [self confirmPaymentIntentWithPaymentMethodInternal:paymentMethod
+    [self confirmPaymentIntentWithPaymentMethodInternal:[self paymentMethodWithMetaData:paymentMethod]
                                          paymentConsent:paymentConsent
                                                  device:device
                                              completion:completion];
@@ -106,65 +107,8 @@
                                returnURL:returnURL
                              autoCapture:session.autoCapture
                               completion:completion];
-    } else if ([self.session isKindOfClass:[AWXRecurringSession class]]) {
-        AWXRecurringSession *session = (AWXRecurringSession *)self.session;
-        __weak __typeof(self) weakSelf = self;
-        [self createPaymentConsentWithPaymentMethod:paymentMethod
-                                         customerId:session.customerId
-                                           currency:session.currency
-                                  nextTriggerByType:session.nextTriggerByType
-                                        requiresCVC:session.requiresCVC
-                              merchantTriggerReason:session.merchantTriggerReason
-                                         completion:^(AWXResponse *_Nullable response, NSError *_Nullable error) {
-                                             __strong __typeof(weakSelf) strongSelf = weakSelf;
-                                             if (response && !error) {
-                                                 NSString *returnURL = session.returnURL;
-                                                 if (strongSelf.paymentConsent && [paymentMethod.type isEqualToString:AWXCardKey]) {
-                                                     returnURL = AWXThreeDSReturnURL;
-                                                 }
-                                                 [strongSelf verifyPaymentConsentWithPaymentMethod:paymentMethod
-                                                                                    paymentConsent:strongSelf.paymentConsent
-                                                                                          currency:session.currency
-                                                                                            amount:session.amount
-                                                                                         returnURL:returnURL
-                                                                                        completion:completion];
-                                             } else {
-                                                 completion(nil, error);
-                                             }
-                                         }];
-    } else if ([self.session isKindOfClass:[AWXRecurringWithIntentSession class]]) {
-        AWXRecurringWithIntentSession *session = (AWXRecurringWithIntentSession *)self.session;
-        __weak __typeof(self) weakSelf = self;
-        [self createPaymentConsentWithPaymentMethod:paymentMethod
-                                         customerId:session.paymentIntent.customerId
-                                           currency:session.paymentIntent.currency
-                                  nextTriggerByType:session.nextTriggerByType
-                                        requiresCVC:session.requiresCVC
-                              merchantTriggerReason:session.merchantTriggerReason
-                                         completion:^(AWXResponse *_Nullable response, NSError *_Nullable error) {
-                                             __strong __typeof(weakSelf) strongSelf = weakSelf;
-                                             if ([paymentMethod.type isEqualToString:AWXCardKey]) {
-                                                 [strongSelf confirmPaymentIntentWithId:session.paymentIntent.Id
-                                                                             customerId:session.paymentIntent.customerId
-                                                                          paymentMethod:paymentMethod
-                                                                         paymentConsent:strongSelf.paymentConsent
-                                                                                 device:device
-                                                                              returnURL:AWXThreeDSReturnURL
-                                                                            autoCapture:session.autoCapture
-                                                                             completion:completion];
-                                             } else {
-                                                 NSString *returnURL = session.returnURL;
-                                                 if (strongSelf.paymentConsent && [paymentMethod.type isEqualToString:AWXCardKey]) {
-                                                     returnURL = AWXThreeDSReturnURL;
-                                                 }
-                                                 [strongSelf verifyPaymentConsentWithPaymentMethod:paymentMethod
-                                                                                    paymentConsent:strongSelf.paymentConsent
-                                                                                          currency:session.paymentIntent.currency
-                                                                                            amount:session.paymentIntent.amount
-                                                                                         returnURL:returnURL
-                                                                                        completion:completion];
-                                             }
-                                         }];
+    } else {
+        [self createPaymentConsentAndConfirmIntentWithPaymentMethod:paymentMethod device:device completion:completion];
     }
 }
 
@@ -276,6 +220,109 @@
                  completion(nil, error);
              }
          }];
+}
+
+- (void)createPaymentConsentAndConfirmIntentWithPaymentMethod:(AWXPaymentMethod *)paymentMethod
+                                                       device:(nullable AWXDevice *)device
+                                                   completion:(AWXRequestHandler)completion {
+    if ([self.session isKindOfClass:[AWXOneOffSession class]]) {
+        __weak __typeof(self) weakSelf = self;
+        [self createPaymentConsentWithPaymentMethod:paymentMethod
+                                         customerId:self.session.customerId
+                                           currency:self.session.currency
+                                  nextTriggerByType:AirwallexNextTriggerByCustomerType
+                                        requiresCVC:true
+                              merchantTriggerReason:AirwallexMerchantTriggerReasonUndefined
+                                         completion:^(AWXResponse *_Nullable response, NSError *_Nullable error) {
+                                             __strong __typeof(weakSelf) strongSelf = weakSelf;
+                                             NSString *returnURL;
+                                             if (strongSelf.paymentConsent && [paymentMethod.type isEqualToString:AWXCardKey]) {
+                                                 returnURL = AWXThreeDSReturnURL;
+                                             }
+                                             AWXOneOffSession *session = (AWXOneOffSession *)self.session;
+                                             [self confirmPaymentIntentWithId:session.paymentIntent.Id
+                                                                   customerId:session.paymentIntent.customerId
+                                                                paymentMethod:paymentMethod
+                                                               paymentConsent:strongSelf.paymentConsent
+                                                                       device:device
+                                                                    returnURL:returnURL
+                                                                  autoCapture:session.autoCapture
+                                                                   completion:completion];
+                                         }];
+    } else if ([self.session isKindOfClass:[AWXRecurringSession class]]) {
+        AWXRecurringSession *session = (AWXRecurringSession *)self.session;
+        __weak __typeof(self) weakSelf = self;
+        [self createPaymentConsentWithPaymentMethod:paymentMethod
+                                         customerId:session.customerId
+                                           currency:session.currency
+                                  nextTriggerByType:session.nextTriggerByType
+                                        requiresCVC:session.requiresCVC
+                              merchantTriggerReason:session.merchantTriggerReason
+                                         completion:^(AWXResponse *_Nullable response, NSError *_Nullable error) {
+                                             __strong __typeof(weakSelf) strongSelf = weakSelf;
+                                             if (response && !error) {
+                                                 NSString *returnURL = session.returnURL;
+                                                 if (strongSelf.paymentConsent && [paymentMethod.type isEqualToString:AWXCardKey]) {
+                                                     returnURL = AWXThreeDSReturnURL;
+                                                 }
+                                                 [strongSelf verifyPaymentConsentWithPaymentMethod:paymentMethod
+                                                                                    paymentConsent:strongSelf.paymentConsent
+                                                                                          currency:session.currency
+                                                                                            amount:session.amount
+                                                                                         returnURL:returnURL
+                                                                                        completion:completion];
+                                             } else {
+                                                 completion(nil, error);
+                                             }
+                                         }];
+    } else if ([self.session isKindOfClass:[AWXRecurringWithIntentSession class]]) {
+        AWXRecurringWithIntentSession *session = (AWXRecurringWithIntentSession *)self.session;
+        __weak __typeof(self) weakSelf = self;
+        [self createPaymentConsentWithPaymentMethod:paymentMethod
+                                         customerId:session.paymentIntent.customerId
+                                           currency:session.paymentIntent.currency
+                                  nextTriggerByType:session.nextTriggerByType
+                                        requiresCVC:session.requiresCVC
+                              merchantTriggerReason:session.merchantTriggerReason
+                                         completion:^(AWXResponse *_Nullable response, NSError *_Nullable error) {
+                                             __strong __typeof(weakSelf) strongSelf = weakSelf;
+                                             if ([paymentMethod.type isEqualToString:AWXCardKey]) {
+                                                 [strongSelf confirmPaymentIntentWithId:session.paymentIntent.Id
+                                                                             customerId:session.paymentIntent.customerId
+                                                                          paymentMethod:paymentMethod
+                                                                         paymentConsent:strongSelf.paymentConsent
+                                                                                 device:device
+                                                                              returnURL:AWXThreeDSReturnURL
+                                                                            autoCapture:session.autoCapture
+                                                                             completion:completion];
+                                             } else {
+                                                 NSString *returnURL = session.returnURL;
+                                                 if (strongSelf.paymentConsent && [paymentMethod.type isEqualToString:AWXCardKey]) {
+                                                     returnURL = AWXThreeDSReturnURL;
+                                                 }
+                                                 [strongSelf verifyPaymentConsentWithPaymentMethod:paymentMethod
+                                                                                    paymentConsent:strongSelf.paymentConsent
+                                                                                          currency:session.paymentIntent.currency
+                                                                                            amount:session.paymentIntent.amount
+                                                                                         returnURL:returnURL
+                                                                                        completion:completion];
+                                             }
+                                         }];
+    }
+}
+
+- (AWXPaymentMethod *)paymentMethodWithMetaData:(AWXPaymentMethod *)paymentMethod {
+    if (![paymentMethod.type isEqualToString:AWXCardKey]) {
+        NSDictionary *metaData = @{@"flow": @"inapp", @"os_type": @"ios"};
+        if (paymentMethod.additionalParams) {
+            NSMutableDictionary *params = paymentMethod.additionalParams.mutableCopy;
+            [params addEntriesFromDictionary:metaData];
+            paymentMethod.additionalParams = params;
+        } else {
+            paymentMethod.additionalParams = metaData;
+        }
+    }
+    return paymentMethod;
 }
 
 @end

--- a/Airwallex/Core/Sources/Internal/AWXPaymentConsentRequest.m
+++ b/Airwallex/Core/Sources/Internal/AWXPaymentConsentRequest.m
@@ -31,8 +31,10 @@
     parameters[@"currency"] = self.currency;
     parameters[@"requires_cvc"] = [NSNumber numberWithBool:self.requiresCVC];
     parameters[@"next_triggered_by"] = FormatNextTriggerByType(self.nextTriggerByType);
-    parameters[@"merchant_trigger_reason"] = FormatMerchantTriggerReason(self.merchantTriggerReason);
-
+    NSString *merchantTriggerReasonString = FormatMerchantTriggerReason(self.merchantTriggerReason);
+    if (merchantTriggerReasonString) {
+        parameters[@"merchant_trigger_reason"] = merchantTriggerReasonString;
+    }
     NSMutableDictionary *paymentParams = @{}.mutableCopy;
     if (self.paymentMethod.Id) {
         paymentParams[@"id"] = self.paymentMethod.Id;

--- a/Airwallex/Core/Sources/Internal/AWXPaymentMethodListViewController.m
+++ b/Airwallex/Core/Sources/Internal/AWXPaymentMethodListViewController.m
@@ -141,11 +141,15 @@
     if ([self.session isKindOfClass:[AWXOneOffSession class]] && customerPaymentConsents.count > 0 && customerPaymentMethods.count > 0) {
         NSArray *paymentConsents = [customerPaymentConsents filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"nextTriggeredBy == %@ AND status == 'VERIFIED'", FormatNextTriggerByType(AirwallexNextTriggerByCustomerType)]];
         NSMutableArray *availablePaymentConsents = [@[] mutableCopy];
+        NSMutableArray *cardsFingerprint = [NSMutableArray new];
         for (AWXPaymentConsent *consent in paymentConsents) {
             AWXPaymentMethod *paymentMethod = [customerPaymentMethods filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"Id == %@", consent.paymentMethod.Id]].firstObject;
             if (paymentMethod != nil) {
-                consent.paymentMethod = paymentMethod;
-                [availablePaymentConsents addObject:consent];
+                if (![cardsFingerprint containsObject:paymentMethod.card.fingerprint]) {
+                    [cardsFingerprint addObject:paymentMethod.card.fingerprint];
+                    consent.paymentMethod = paymentMethod;
+                    [availablePaymentConsents addObject:consent];
+                }
             }
         }
         self.availablePaymentConsents = availablePaymentConsents;

--- a/Airwallex/CoreTests/API/AWXPaymentConsentRequestTest.m
+++ b/Airwallex/CoreTests/API/AWXPaymentConsentRequestTest.m
@@ -1,0 +1,24 @@
+//
+//  AWXPaymentConsentRequestTest.m
+//  CoreTests
+//
+//  Created by Hector.Huang on 2022/8/23.
+//  Copyright © 2022 Airwallex. All rights reserved.
+//
+
+#import "AWXPaymentConsentRequest.h"
+#import <XCTest/XCTest.h>
+
+@interface AWXPaymentConsentRequestTest : XCTestCase
+
+@end
+
+@implementation AWXPaymentConsentRequestTest
+
+- (void)testCreatePaymentConsentRequestParameters {
+    AWXCreatePaymentConsentRequest *request = [AWXCreatePaymentConsentRequest new];
+    request.merchantTriggerReason = AirwallexMerchantTriggerReasonScheduled;
+    XCTAssertEqualObjects(request.parameters[@"merchant_trigger_reason"], @"scheduled");
+}
+
+@end

--- a/Airwallex/CoreTests/AWXConstantsTest.m
+++ b/Airwallex/CoreTests/AWXConstantsTest.m
@@ -37,6 +37,12 @@
 
 @implementation AWXConstantsTest
 
+- (void)testFormatMerchantTriggerReason {
+    XCTAssertNil(FormatMerchantTriggerReason(AirwallexMerchantTriggerReasonUndefined));
+    XCTAssertEqualObjects(FormatMerchantTriggerReason(AirwallexMerchantTriggerReasonScheduled), @"scheduled");
+    XCTAssertEqualObjects(FormatMerchantTriggerReason(AirwallexMerchantTriggerReasonUnscheduled), @"unscheduled");
+}
+
 - (void)testApplePayKey {
     XCTAssertEqualObjects(AWXApplePayKey, @"applepay");
 }

--- a/Airwallex/CoreTests/AWXDefaultProviderTest.m
+++ b/Airwallex/CoreTests/AWXDefaultProviderTest.m
@@ -14,9 +14,45 @@
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 
-@interface AWXDefaultProviderTest : XCTestCase
+@interface AWXDefaultProvider (Testing)
+
+- (void)createPaymentConsentWithPaymentMethod:(AWXPaymentMethod *)paymentMethod
+                                   customerId:(nullable NSString *)customerId
+                                     currency:(NSString *)currency
+                            nextTriggerByType:(AirwallexNextTriggerByType)nextTriggerByType
+                                  requiresCVC:(BOOL)requiresCVC
+                        merchantTriggerReason:(AirwallexMerchantTriggerReason)merchantTriggerReason
+                                   completion:(AWXRequestHandler)completion;
+
+- (void)confirmPaymentIntentWithId:(NSString *)paymentIntentId
+                        customerId:(nullable NSString *)customerId
+                     paymentMethod:(AWXPaymentMethod *)paymentMethod
+                    paymentConsent:(nullable AWXPaymentConsent *)paymentConsent
+                            device:(AWXDevice *)device
+                         returnURL:(NSString *)returnURL
+                       autoCapture:(BOOL)autoCapture
+                        completion:(AWXRequestHandler)completion;
+
+- (void)verifyPaymentConsentWithPaymentMethod:(AWXPaymentMethod *)paymentMethod
+                               paymentConsent:(AWXPaymentConsent *)paymentConsent
+                                     currency:(NSString *)currency
+                                       amount:(NSDecimalNumber *)amount
+                                    returnURL:(NSString *)returnURL
+                                   completion:(AWXRequestHandler)completion;
 
 @end
+
+@interface AWXDefaultProviderTest : XCTestCase
+
+@property (nonatomic, strong) AWXDefaultProvider *provider;
+@property (nonatomic, strong) AWXDefaultProvider *providerMock;
+@property (nonatomic, strong) AWXConfirmPaymentIntentResponse *response;
+@property (nonatomic, strong) NSError *error;
+
+@end
+
+NSString *const kProviderKey = @"PROVIDER";
+NSString *const kMockKey = @"MOCK";
 
 @implementation AWXDefaultProviderTest
 
@@ -26,9 +62,125 @@
 }
 
 - (void)testConfirmPaymentIntentWithoutCompletionBlock {
-    AWXSession *session = [AWXSession new];
-    AWXProviderDelegateSpy *spy = [AWXProviderDelegateSpy new];
+    [self createProviderAndMockWithSession:[AWXSession new]];
 
+    [self.provider confirmPaymentIntentWithPaymentMethod:[AWXPaymentMethod new] paymentConsent:nil device:nil];
+
+    OCMVerify(times(1), [self.providerMock confirmPaymentIntentWithPaymentMethod:[OCMArg any]
+                                                                  paymentConsent:[OCMArg any]
+                                                                          device:[OCMArg any]
+                                                                      completion:[OCMArg any]]);
+    OCMVerify(times(1), [self.providerMock completeWithResponse:self.response error:self.error]);
+}
+
+- (void)testCreatePaymentConsentAndConfirmIntentWithOneOffSession {
+    [self createProviderAndMockWithSession:[AWXOneOffSession new]];
+    [self.provider createPaymentConsentAndConfirmIntentWithPaymentMethod:[AWXPaymentMethod new]
+                                                                  device:nil];
+
+    OCMVerify(times(1), [self.providerMock createPaymentConsentWithPaymentMethod:[OCMArg any]
+                                                                      customerId:[OCMArg any]
+                                                                        currency:[OCMArg any]
+                                                               nextTriggerByType:AirwallexNextTriggerByCustomerType
+                                                                     requiresCVC:[OCMArg any]
+                                                           merchantTriggerReason:AirwallexMerchantTriggerReasonUndefined
+                                                                      completion:([OCMArg invokeBlockWithArgs:self.response, self.error, nil])]);
+    OCMVerify(times(1), [self.providerMock confirmPaymentIntentWithId:[OCMArg any]
+                                                           customerId:[OCMArg any]
+                                                        paymentMethod:[OCMArg any]
+                                                       paymentConsent:[OCMArg any]
+                                                               device:[OCMArg any]
+                                                            returnURL:[OCMArg any]
+                                                          autoCapture:NO
+                                                           completion:([OCMArg invokeBlockWithArgs:self.response, self.error, nil])]);
+}
+
+- (void)testCreatePaymentConsentAndConfirmIntentWithRecurringSession {
+    AWXRecurringSession *session = [AWXRecurringSession new];
+    session.requiresCVC = YES;
+    [self createProviderAndMockWithSession:session hasError:NO];
+    [self.provider createPaymentConsentAndConfirmIntentWithPaymentMethod:[AWXPaymentMethod new]
+                                                                  device:nil];
+    OCMVerify(times(1), [self.providerMock createPaymentConsentWithPaymentMethod:[OCMArg any]
+                                                                 customerId:[OCMArg any]
+                                                                   currency:[OCMArg any]
+                                                          nextTriggerByType:AirwallexNextTriggerByCustomerType
+                                                                requiresCVC:[OCMArg any]
+                                                      merchantTriggerReason:AirwallexMerchantTriggerReasonUndefined
+                                                                      completion:([OCMArg invokeBlockWithArgs:self.response, [NSNull null], nil])]);
+    OCMVerify(times(1), [self.providerMock verifyPaymentConsentWithPaymentMethod:[OCMArg any]
+                                                                  paymentConsent:[OCMArg any]
+                                                                        currency:[OCMArg any]
+                                                                          amount:[OCMArg any]
+                                                                       returnURL:[OCMArg any]
+                                                                      completion:([OCMArg invokeBlockWithArgs:self.response, self.error, nil])]);
+}
+
+- (void)testCreatePaymentConsentAndConfirmIntentWithRecurringSessionWhenError {
+    AWXRecurringSession *session = [AWXRecurringSession new];
+    session.requiresCVC = YES;
+    [self createProviderAndMockWithSession:session];
+    [self.provider createPaymentConsentAndConfirmIntentWithPaymentMethod:[AWXPaymentMethod new]
+                                                                  device:nil];
+    OCMVerify(times(1), [self.providerMock completeWithResponse:nil error:self.error]);
+}
+
+- (void)testCreatePaymentConsentAndConfirmIntentWithRecurringWithIntentSession {
+    AWXRecurringWithIntentSession *session = [AWXRecurringWithIntentSession new];
+    AWXPaymentMethod *paymentMethod = [AWXPaymentMethod new];
+    paymentMethod.additionalParams = [NSDictionary dictionary];
+    session.requiresCVC = YES;
+    [self createProviderAndMockWithSession:session];
+    [self.provider createPaymentConsentAndConfirmIntentWithPaymentMethod:paymentMethod
+                                                                  device:nil];
+
+    OCMVerify(times(1), [self.providerMock createPaymentConsentWithPaymentMethod:[OCMArg any]
+                                                                      customerId:[OCMArg any]
+                                                                        currency:[OCMArg any]
+                                                               nextTriggerByType:AirwallexNextTriggerByCustomerType
+                                                                     requiresCVC:[OCMArg any]
+                                                           merchantTriggerReason:AirwallexMerchantTriggerReasonUndefined
+                                                                      completion:([OCMArg invokeBlockWithArgs:self.response, self.error, nil])]);
+    OCMVerify(times(1), [self.providerMock verifyPaymentConsentWithPaymentMethod:[OCMArg any]
+                                                                  paymentConsent:[OCMArg any]
+                                                                        currency:[OCMArg any]
+                                                                          amount:[OCMArg any]
+                                                                       returnURL:[OCMArg any]
+                                                                      completion:([OCMArg invokeBlockWithArgs:self.response, self.error, nil])]);
+}
+
+- (void)testCreatePaymentConsentAndConfirmIntentWithRecurringWithIntentSessionAndCard {
+    AWXRecurringWithIntentSession *session = [AWXRecurringWithIntentSession new];
+    session.requiresCVC = YES;
+    [self createProviderAndMockWithSession:session];
+    AWXPaymentMethod *paymentMethod = [AWXPaymentMethod new];
+    paymentMethod.type = AWXCardKey;
+    [self.provider createPaymentConsentAndConfirmIntentWithPaymentMethod:paymentMethod
+                                                                  device:nil];
+
+    OCMVerify(times(1), [self.providerMock createPaymentConsentWithPaymentMethod:[OCMArg any]
+                                                                      customerId:[OCMArg any]
+                                                                        currency:[OCMArg any]
+                                                               nextTriggerByType:AirwallexNextTriggerByCustomerType
+                                                                     requiresCVC:[OCMArg any]
+                                                           merchantTriggerReason:AirwallexMerchantTriggerReasonUndefined
+                                                                      completion:([OCMArg invokeBlockWithArgs:self.response, self.error, nil])]);
+    OCMVerify(times(1), [self.providerMock confirmPaymentIntentWithId:[OCMArg any]
+                                                           customerId:[OCMArg any]
+                                                        paymentMethod:[OCMArg any]
+                                                       paymentConsent:[OCMArg any]
+                                                               device:[OCMArg any]
+                                                            returnURL:[OCMArg any]
+                                                          autoCapture:NO
+                                                           completion:([OCMArg invokeBlockWithArgs:self.response, self.error, nil])]);
+}
+
+- (void)createProviderAndMockWithSession:(AWXSession *)session {
+    [self createProviderAndMockWithSession:session hasError:YES];
+}
+
+- (void)createProviderAndMockWithSession:(AWXSession *)session hasError:(BOOL)hasError {
+    AWXProviderDelegateSpy *spy = [AWXProviderDelegateSpy new];
     AWXDefaultProvider *provider = [[AWXDefaultProvider alloc] initWithDelegate:spy session:session];
     id providerMock = OCMPartialMock(provider);
 
@@ -38,14 +190,42 @@
                                                  paymentConsent:[OCMArg any]
                                                          device:[OCMArg any]
                                                      completion:([OCMArg invokeBlockWithArgs:response, error, nil])]);
-
-    [provider confirmPaymentIntentWithPaymentMethod:[AWXPaymentMethod new] paymentConsent:nil device:nil];
-
-    OCMVerify(times(1), [providerMock confirmPaymentIntentWithPaymentMethod:[OCMArg any]
-                                                             paymentConsent:[OCMArg any]
-                                                                     device:[OCMArg any]
-                                                                 completion:[OCMArg any]]);
-    OCMVerify(times(1), [providerMock completeWithResponse:response error:error]);
+    if (hasError) {
+        OCMStub([providerMock createPaymentConsentWithPaymentMethod:[OCMArg any]
+                                                         customerId:[OCMArg any]
+                                                           currency:[OCMArg any]
+                                                  nextTriggerByType:AirwallexNextTriggerByCustomerType
+                                                        requiresCVC:[OCMArg any]
+                                              merchantTriggerReason:AirwallexMerchantTriggerReasonUndefined
+                                                         completion:([OCMArg invokeBlockWithArgs:response, error, nil])]);
+    } else {
+        OCMStub([providerMock createPaymentConsentWithPaymentMethod:[OCMArg any]
+                                                         customerId:[OCMArg any]
+                                                           currency:[OCMArg any]
+                                                  nextTriggerByType:AirwallexNextTriggerByCustomerType
+                                                        requiresCVC:[OCMArg any]
+                                              merchantTriggerReason:AirwallexMerchantTriggerReasonUndefined
+                                                         completion:([OCMArg invokeBlockWithArgs:response, [NSNull null], nil])]);
+    }
+    
+    OCMStub([providerMock confirmPaymentIntentWithId:[OCMArg any]
+                                          customerId:[OCMArg any]
+                                       paymentMethod:[OCMArg any]
+                                      paymentConsent:[OCMArg any]
+                                              device:[OCMArg any]
+                                           returnURL:[OCMArg any]
+                                         autoCapture:NO
+                                          completion:([OCMArg invokeBlockWithArgs:response, error, nil])]);
+    OCMStub([providerMock verifyPaymentConsentWithPaymentMethod:[OCMArg any]
+                                                 paymentConsent:[OCMArg any]
+                                                       currency:[OCMArg any]
+                                                         amount:[OCMArg any]
+                                                      returnURL:[OCMArg any]
+                                                     completion:([OCMArg invokeBlockWithArgs:response, error, nil])]);
+    self.provider = provider;
+    self.providerMock = providerMock;
+    self.response = response;
+    self.error = error;
 }
 
 @end

--- a/Airwallex/CoreTests/AWXDefaultProviderTest.m
+++ b/Airwallex/CoreTests/AWXDefaultProviderTest.m
@@ -102,11 +102,11 @@ NSString *const kMockKey = @"MOCK";
     [self.provider createPaymentConsentAndConfirmIntentWithPaymentMethod:[AWXPaymentMethod new]
                                                                   device:nil];
     OCMVerify(times(1), [self.providerMock createPaymentConsentWithPaymentMethod:[OCMArg any]
-                                                                 customerId:[OCMArg any]
-                                                                   currency:[OCMArg any]
-                                                          nextTriggerByType:AirwallexNextTriggerByCustomerType
-                                                                requiresCVC:[OCMArg any]
-                                                      merchantTriggerReason:AirwallexMerchantTriggerReasonUndefined
+                                                                      customerId:[OCMArg any]
+                                                                        currency:[OCMArg any]
+                                                               nextTriggerByType:AirwallexNextTriggerByCustomerType
+                                                                     requiresCVC:[OCMArg any]
+                                                           merchantTriggerReason:AirwallexMerchantTriggerReasonUndefined
                                                                       completion:([OCMArg invokeBlockWithArgs:self.response, [NSNull null], nil])]);
     OCMVerify(times(1), [self.providerMock verifyPaymentConsentWithPaymentMethod:[OCMArg any]
                                                                   paymentConsent:[OCMArg any]
@@ -207,7 +207,7 @@ NSString *const kMockKey = @"MOCK";
                                               merchantTriggerReason:AirwallexMerchantTriggerReasonUndefined
                                                          completion:([OCMArg invokeBlockWithArgs:response, [NSNull null], nil])]);
     }
-    
+
     OCMStub([providerMock confirmPaymentIntentWithId:[OCMArg any]
                                           customerId:[OCMArg any]
                                        paymentMethod:[OCMArg any]


### PR DESCRIPTION
This pr enables save card feature in one-off payment by:

- Display toggle in card payment UI when having customer ID
- Create payment consent using the card payment method and then confirm payment intent

<img src="https://user-images.githubusercontent.com/107159278/186195423-eb0c78c8-c8fe-4a59-a102-311110b7e010.png" width=200/>

- Removes duplicate cards based on their `fingerprint`

Before change:
<img src="https://user-images.githubusercontent.com/107159278/186195707-27740dd0-9b0e-4198-8c88-885876a1690c.png" width=200/>

After change:
<img src="https://user-images.githubusercontent.com/107159278/186292188-e7d0059c-a3de-45ed-9cf8-5278a3c22887.png" width=200/>
