### PR TITLE
chore: silence push notification warning

### DIFF
--- a/Examples/Examples/Examples.entitlements
+++ b/Examples/Examples/Examples.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>development</string>
 	<key>com.apple.developer.in-app-payments</key>
 	<array>
 		<string>merchant.com.airwallex.paymentacceptance</string>


### PR DESCRIPTION
This PR enabled push notification for the Example app. 

We were getting email warnings saying this:

<img width="731" alt="Screen Shot 2022-10-07 at 4 05 42 pm" src="https://user-images.githubusercontent.com/73088020/194471769-19c6df4e-2730-421e-a007-6406879e54da.png">

The Example app doesn't even have push notification enabled in either the App ID configuration or the entitlement file. According to the thread https://developer.apple.com/forums/thread/15011, it could still be a false positive.

Regardless, we enable the push and silence the warning.