### PR TITLE
[MOB-1048] fix: workaround an issue where it's not allowed to push directly into protected branches

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,4 +1,4 @@
-name: Semantic Release
+name: Create Release
 
 on:
   workflow_dispatch:
@@ -17,13 +17,17 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          # Bypass protected branch setting by using a service account PAT
+          # see more at: https://github.com/community/community/discussions/13836
+          token: ${{ secrets.SERVICE_ACCOUNT_PAT }}
       
       - name: Work out the new version via Semantic Release
         if: ${{ inputs.version == '' }}
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v3
         id: semantic
         with:
           branch: ${{ github.ref_name }}
+          dry_run: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Checkout project
       uses: actions/checkout@v3
       with:
-          fetch-depth: 0
+        fetch-depth: 0
     
     - name: Setup Xcode version
       uses: maxim-lobanov/setup-xcode@v1.4.1
@@ -60,5 +60,4 @@ jobs:
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-      run: sonar-scanner
-          -Dsonar.qualitygate.wait=true
+      run: sonar-scanner -Dsonar.qualitygate.wait=true


### PR DESCRIPTION
There is a limitation which wasn't picked up during my tests:

GitHub won't allow CI pipelines to push commits directly into a protected branch. The feature branch I had didn't have the protected rule set up so this was missed. The issue was then discovered after the PR was merged and the action failed because of this. https://github.com/airwallex/airwallex-payment-ios/actions/runs/3202752812/jobs/5232062599

More on the issue can be found at https://github.com/community/community/discussions/13836.

This PR workarounds the issue by using a special PAT generated under the mobile service account. The service account has admin permissions to bypass the limitation.