### PR TITLE
[MOB-1048] chore: used service account PAT for tagging in order to trigger another workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -36,7 +36,7 @@ jobs:
           echo "VERSION=${{ inputs.version || steps.semantic.outputs.new_release_version }}" >> $GITHUB_ENV
 
       - name: Restore Cocoapods cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: Pods
           key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
@@ -60,3 +60,4 @@ jobs:
           generateReleaseNotes: ${{ steps.semantic.outcome != 'success' }}
           commit: ${{ steps.commit.outputs.commit_hash }}
           tag: ${{ env.VERSION }}
+          token: ${{ secrets.SERVICE_ACCOUNT_PAT }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
         xcode-version: latest-stable
 
     - name: Restore Cocoapods cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: cache
       with:
         path: Pods
@@ -31,8 +31,7 @@ jobs:
           ${{ runner.os }}-pods-
 
     - name: Cocoapods
-      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-      run: pod install --verbose --repo-update
+      run: pod install --verbose
       
       # Sonar coverage is broken up into two formats for Objective-C and Swift code. 
       # All Objective-C analysis requires the build-wrapper (https://docs.sonarqube.org/latest/analysis/languages/cfamily/). Without it, sonar-scanner


### PR DESCRIPTION
There are two workflows for automatic releasing the SDK:
- versioning bump workflow: the workflow used to figure out the next version, update the files that require version, commit the changes, tag the commit and then create a GitHub release.
- deploy workflow: whenever a tag is created, this workflow will download the tagged commit and make a deployment.

We rely on the first workflow to create a tag which will trigger the second workflow. However, it turns out the tagging created by GitHub bots [won't be able to trigger another workflow](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow).

This PR workarounds that, just like the previous PR #38, by using the service account's PAT.