### PR TITLE
[MOB-1113] Set autoCapture to true by default

### DIFF
--- a/Airwallex/Core/Sources/AWXSession.h
+++ b/Airwallex/Core/Sources/AWXSession.h
@@ -98,11 +98,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)requiresCVC;
 
-/**
- Return whether auto_capture is enabled.
- */
-- (BOOL)autoCapture;
-
 @end
 
 /**

--- a/Airwallex/Core/Sources/AWXSession.m
+++ b/Airwallex/Core/Sources/AWXSession.m
@@ -148,21 +148,17 @@ static NSString *const recurring = @"recurring";
     return NO;
 }
 
-- (BOOL)autoCapture {
-    if ([self isKindOfClass:[AWXOneOffSession class]]) {
-        AWXOneOffSession *session = (AWXOneOffSession *)self;
-        return session.autoCapture;
-    }
-    if ([self isKindOfClass:[AWXRecurringWithIntentSession class]]) {
-        AWXRecurringWithIntentSession *session = (AWXRecurringWithIntentSession *)self;
-        return session.autoCapture;
-    }
-    return YES;
-}
-
 @end
 
 @implementation AWXOneOffSession
+
+- (instancetype)init {
+    if (self = [super init]) {
+        self.autoCapture = YES;
+    }
+
+    return self;
+}
 
 @end
 
@@ -175,6 +171,14 @@ static NSString *const recurring = @"recurring";
 @end
 
 @implementation AWXRecurringWithIntentSession
+
+- (instancetype)init {
+    if (self = [super init]) {
+        self.autoCapture = YES;
+    }
+
+    return self;
+}
 
 - (NSString *)transactionMode {
     return recurring;

--- a/Airwallex/CoreTests/AWXDefaultProviderTest.m
+++ b/Airwallex/CoreTests/AWXDefaultProviderTest.m
@@ -92,7 +92,7 @@ NSString *const kMockKey = @"MOCK";
                                                        paymentConsent:[OCMArg any]
                                                                device:[OCMArg any]
                                                             returnURL:[OCMArg any]
-                                                          autoCapture:NO
+                                                          autoCapture:YES
                                                            completion:([OCMArg invokeBlockWithArgs:self.response, self.error, nil])]);
 }
 
@@ -172,7 +172,7 @@ NSString *const kMockKey = @"MOCK";
                                                        paymentConsent:[OCMArg any]
                                                                device:[OCMArg any]
                                                             returnURL:[OCMArg any]
-                                                          autoCapture:NO
+                                                          autoCapture:YES
                                                            completion:([OCMArg invokeBlockWithArgs:self.response, self.error, nil])]);
 }
 
@@ -215,7 +215,7 @@ NSString *const kMockKey = @"MOCK";
                                       paymentConsent:[OCMArg any]
                                               device:[OCMArg any]
                                            returnURL:[OCMArg any]
-                                         autoCapture:NO
+                                         autoCapture:YES
                                           completion:([OCMArg invokeBlockWithArgs:response, error, nil])]);
     OCMStub([providerMock verifyPaymentConsentWithPaymentMethod:[OCMArg any]
                                                  paymentConsent:[OCMArg any]

--- a/Airwallex/CoreTests/Models/AWXSessionTest.m
+++ b/Airwallex/CoreTests/Models/AWXSessionTest.m
@@ -35,12 +35,12 @@
     session.billing = billing;
     session.returnURL = @"airwallex://";
     session.paymentIntent = self.paymentIntent;
-    session.autoCapture = YES;
     XCTAssertNotNil(session.customerPaymentConsents);
     XCTAssertNotNil(session.customerPaymentMethods);
     XCTAssertNil(session.customerId);
     XCTAssertNotNil(session.currency);
     XCTAssertNotNil(session.amount);
+    XCTAssertTrue(session.autoCapture);
 }
 
 - (void)testRecurringSession {
@@ -69,13 +69,13 @@
     session.paymentIntent = self.paymentIntent;
     session.nextTriggerByType = AirwallexNextTriggerByCustomerType;
     session.requiresCVC = YES;
-    session.autoCapture = YES;
     session.merchantTriggerReason = AirwallexMerchantTriggerReasonUnscheduled;
     XCTAssertNotNil(session.customerPaymentConsents);
     XCTAssertNotNil(session.customerPaymentMethods);
     XCTAssertNil(session.customerId);
     XCTAssertNotNil(session.currency);
     XCTAssertNotNil(session.amount);
+    XCTAssertTrue(session.autoCapture);
 }
 
 @end

--- a/Examples/Examples/AirwallexExamplesKeys.m
+++ b/Examples/Examples/AirwallexExamplesKeys.m
@@ -50,7 +50,6 @@
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:kCachedCheckoutMode];
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:kCachedNextTriggerBy];
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:kCachedRequiresCVC];
-    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kCachedAutoCapture];
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:kCachedCustomerID];
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:kCachedApiKey];
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:kCachedClientId];
@@ -58,6 +57,7 @@
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:kCachedCurrency];
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:kCachedCountryCode];
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:kCachedReturnURL];
+    [[NSUserDefaults standardUserDefaults] setBool:YES forKey:kCachedAutoCapture];
     [[NSUserDefaults standardUserDefaults] synchronize];
 
     [self syncKeys];


### PR DESCRIPTION
This pr
- sets `autoCapture` of one off and recurring with intent session to `true` by default so that the payment will be automatically captured without customer's extra config.
- also sets the demo app's `autoCapture` in Settings as turned on by default.