### PR TITLE
[MOB-1594] Show schema field when bank list is empty

### DIFF
--- a/Airwallex/Airwallex.xcodeproj/project.pbxproj
+++ b/Airwallex/Airwallex.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		186277D529E797320002892A /* AWXDefaultProvider+Security.m in Sources */ = {isa = PBXBuildFile; fileRef = 189E3AE429865AE100F3037F /* AWXDefaultProvider+Security.m */; };
 		186277D729E7C0530002892A /* AirTracker.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 186277D629E7C0530002892A /* AirTracker.xcframework */; };
 		186277D829E7C0530002892A /* AirTracker.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 186277D629E7C0530002892A /* AirTracker.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		186277DB2A381A240002892A /* AWXSchemaProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 186277DA2A381A240002892A /* AWXSchemaProviderTests.m */; };
 		187AFA6928B522C000561EEB /* AWXPaymentConsentRequestTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 187AFA6828B522C000561EEB /* AWXPaymentConsentRequestTest.m */; };
 		189E3AF329875BEC00F3037F /* AWXSecurityService.m in Sources */ = {isa = PBXBuildFile; fileRef = 5775CF9C26E5F8CC00C6AFE3 /* AWXSecurityService.m */; };
 		189E3AFA29875E2D00F3037F /* AWXSecurityService.m in Sources */ = {isa = PBXBuildFile; fileRef = 5775CF9C26E5F8CC00C6AFE3 /* AWXSecurityService.m */; };
@@ -378,6 +379,7 @@
 		186277CA29E78F840002892A /* RLTMXProfilingConnections.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RLTMXProfilingConnections.xcframework; path = ../Frameworks/RLTMXProfilingConnections.xcframework; sourceTree = "<group>"; };
 		186277CB29E78F840002892A /* RLTMXProfiling.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RLTMXProfiling.xcframework; path = ../Frameworks/RLTMXProfiling.xcframework; sourceTree = "<group>"; };
 		186277D629E7C0530002892A /* AirTracker.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = AirTracker.xcframework; path = ../Frameworks/AirTracker.xcframework; sourceTree = "<group>"; };
+		186277DA2A381A240002892A /* AWXSchemaProviderTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWXSchemaProviderTests.m; sourceTree = "<group>"; };
 		187AFA6828B522C000561EEB /* AWXPaymentConsentRequestTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWXPaymentConsentRequestTest.m; sourceTree = "<group>"; };
 		189E3AE329865AE100F3037F /* AWXDefaultProvider+Security.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AWXDefaultProvider+Security.h"; sourceTree = "<group>"; };
 		189E3AE429865AE100F3037F /* AWXDefaultProvider+Security.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "AWXDefaultProvider+Security.m"; sourceTree = "<group>"; };
@@ -1037,6 +1039,7 @@
 				5775CEBA26E5DF3300C6AFE3 /* Info.plist */,
 				1803601E2873D73A003EA943 /* AWXPaymentFormViewModelTests.m */,
 				18E0571429C95A6A0099388A /* AWXRedirectActionProviderTests.m */,
+				186277DA2A381A240002892A /* AWXSchemaProviderTests.m */,
 			);
 			path = RedirectTests;
 			sourceTree = "<group>";
@@ -1948,6 +1951,7 @@
 			files = (
 				18E0571629C95FDB0099388A /* AWXProviderDelegateSpy.m in Sources */,
 				18E0571529C95A6A0099388A /* AWXRedirectActionProviderTests.m in Sources */,
+				186277DB2A381A240002892A /* AWXSchemaProviderTests.m in Sources */,
 				1803601F2873D73A003EA943 /* AWXPaymentFormViewModelTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Airwallex/Core/Sources/Internal/AWXPaymentMethodListViewController.m
+++ b/Airwallex/Core/Sources/Internal/AWXPaymentMethodListViewController.m
@@ -304,7 +304,7 @@
             [provider confirmPaymentIntentWithPaymentMethod:paymentConsent.paymentMethod paymentConsent:paymentConsent device:nil];
             self.provider = provider;
         }
-        
+
         if (paymentConsent.paymentMethod.type.length > 0) {
             [[AWXAnalyticsLogger shared] logActionWithName:@"select_payment" additionalInfo:@{@"paymentMethod": paymentConsent.paymentMethod.type}];
         }

--- a/Airwallex/Redirect/AWXSchemaProvider.m
+++ b/Airwallex/Redirect/AWXSchemaProvider.m
@@ -152,16 +152,20 @@
 }
 
 - (void)verifyAvailableBankList:(AWXGetAvailableBanksResponse *)response {
-    AWXFormMapping *formMapping = [AWXFormMapping new];
-    formMapping.title = NSLocalizedString(@"Select your bank", @"Select your bank");
-    NSMutableArray *forms = [NSMutableArray array];
-    for (AWXBank *bank in response.items) {
-        [forms addObject:[AWXForm formWithKey:bank.name type:AWXFormTypeListCell title:bank.displayName logo:bank.resources.logoURL]];
-    }
-    formMapping.forms = forms;
-    self.banksMapping = formMapping;
+    if (response.items.count) {
+        AWXFormMapping *formMapping = [AWXFormMapping new];
+        formMapping.title = NSLocalizedString(@"Select your bank", @"Select your bank");
+        NSMutableArray *forms = [NSMutableArray array];
+        for (AWXBank *bank in response.items) {
+            [forms addObject:[AWXForm formWithKey:bank.name type:AWXFormTypeListCell title:bank.displayName logo:bank.resources.logoURL]];
+        }
+        formMapping.forms = forms;
+        self.banksMapping = formMapping;
 
-    [self renderBanks];
+        [self renderBanks];
+    } else {
+        [self renderFields:NO];
+    }
 }
 
 - (void)renderBanks {

--- a/Airwallex/RedirectTests/AWXSchemaProviderTests.m
+++ b/Airwallex/RedirectTests/AWXSchemaProviderTests.m
@@ -1,0 +1,88 @@
+//
+//  AWXSchemaProviderTests.m
+//  RedirectTests
+//
+//  Created by Hector.Huang on 2023/6/13.
+//  Copyright © 2023 Airwallex. All rights reserved.
+//
+
+#import "AWXFormMapping.h"
+#import "AWXPaymentFormViewController.h"
+#import "AWXPaymentMethod.h"
+#import "AWXPaymentMethodRequest.h"
+#import "AWXPaymentMethodResponse.h"
+#import "AWXProviderDelegateSpy.h"
+#import "AWXSchemaProvider.h"
+#import "AWXSession.h"
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+
+@interface AWXSchemaProviderTests : XCTestCase
+
+@property (nonatomic, weak) id<AWXProviderDelegate> delegate;
+
+@end
+
+@implementation AWXSchemaProviderTests
+
+- (void)setUp {
+    id spy = OCMClassMock([AWXProviderDelegateSpy class]);
+    self.delegate = spy;
+}
+
+- (void)testHandleFlowWhenBankListEmpty {
+    AWXSchemaProvider *provider = [self createProvider:NO];
+    [provider handleFlow];
+    OCMVerify(times(1), [_delegate provider:provider shouldPresentViewController:[OCMArg isKindOfClass:[AWXPaymentFormViewController class]] forceToDismiss:NO withAnimation:NO]);
+}
+
+- (void)testHandleFlowWhenBankListNotEmpty {
+    AWXSchemaProvider *provider = [self createProvider:YES];
+    [provider handleFlow];
+    OCMVerify(times(1), [_delegate provider:provider
+                            shouldPresentViewController:[OCMArg checkWithBlock:^BOOL(id obj) {
+                                AWXPaymentFormViewController *controller = (AWXPaymentFormViewController *)obj;
+                                XCTAssertEqualObjects(controller.formMapping.title, @"Select your bank");
+                                return true;
+                            }]
+                                         forceToDismiss:NO
+                                          withAnimation:NO]);
+}
+
+- (AWXSchemaProvider *)createProvider:(BOOL)hasBanks {
+    AWXSession *session = [AWXSession new];
+    AWXPaymentMethodType *paymentMethod = [AWXPaymentMethodType new];
+    AWXSchemaProvider *provider = [[AWXSchemaProvider alloc] initWithDelegate:_delegate session:session paymentMethodType:paymentMethod];
+
+    id apiClientMock = OCMClassMock([AWXAPIClient class]);
+    OCMStub([apiClientMock initWithConfiguration:[OCMArg any]]).andReturn(apiClientMock);
+    OCMStub([apiClientMock alloc]).andReturn(apiClientMock);
+
+    AWXField *textField = [AWXField new];
+    textField.uiType = @"text";
+    AWXField *banksField = [AWXField new];
+    banksField.type = @"banks";
+    banksField.uiType = @"logo_list";
+    AWXSchema *schema = [AWXSchema new];
+    schema.transactionMode = @"oneoff";
+    schema.fields = @[banksField, textField];
+
+    AWXGetPaymentMethodTypeResponse *response = [AWXGetPaymentMethodTypeResponse new];
+    response.schemas = @[schema];
+    OCMStub([apiClientMock send:[OCMArg isKindOfClass:[AWXGetPaymentMethodTypeRequest class]] handler:([OCMArg invokeBlockWithArgs:response, [NSNull null], nil])]);
+
+    AWXResponse *banksResponse;
+    if (hasBanks) {
+        NSDictionary *dictionary = @{
+            @"items": @[@{@"bank_name": @"CBA"}]
+        };
+        NSData *bankData = [NSJSONSerialization dataWithJSONObject:dictionary options:0 error:nil];
+        banksResponse = [AWXGetAvailableBanksResponse parse:bankData];
+    } else {
+        banksResponse = [AWXGetAvailableBanksResponse new];
+    }
+    OCMStub([apiClientMock send:[OCMArg isKindOfClass:[AWXGetAvailableBanksRequest class]] handler:([OCMArg invokeBlockWithArgs:banksResponse, [NSNull null], nil])]);
+    return provider;
+}
+
+@end


### PR DESCRIPTION
This pr supports KCP by:
- Skip bank selection when bank list is empty from response and show user info input field

![Simulator Screen Recording - iPhone 14 Pro - 2023-06-13 at 17 08 28](https://github.com/airwallex/airwallex-payment-ios/assets/107159278/5d251fdb-1b9e-44e9-935b-bd3a00c9d63f)