### PR TITLE
[MOB-1832] Change CTA title in recurring session

### DIFF
--- a/Airwallex/Card/Internal/AWXCardViewController.m
+++ b/Airwallex/Card/Internal/AWXCardViewController.m
@@ -167,7 +167,7 @@ typedef enum {
 
     _confirmButton = [AWXActionButton new];
     _confirmButton.enabled = YES;
-    [_confirmButton setTitle:NSLocalizedString(@"Pay", @"Pay button title") forState:UIControlStateNormal];
+    [_confirmButton setTitle:_viewModel.ctaTitle forState:UIControlStateNormal];
     [_confirmButton addTarget:self action:@selector(confirmPayment:) forControlEvents:UIControlEventTouchUpInside];
     [stackView addArrangedSubview:_confirmButton];
     [_confirmButton.heightAnchor constraintEqualToConstant:52].active = YES;

--- a/Airwallex/Card/Internal/AWXCardViewModel.h
+++ b/Airwallex/Card/Internal/AWXCardViewModel.h
@@ -18,6 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface AWXCardViewModel : NSObject
 
+@property (nonatomic, copy, readonly) NSString *ctaTitle;
 @property (nonatomic, copy, readonly) NSString *pageName;
 @property (nonatomic, copy, readonly) NSDictionary<NSString *, id> *additionalInfo;
 @property (nonatomic, readonly) BOOL isReusingShippingAsBillingInformation;

--- a/Airwallex/Card/Internal/AWXCardViewModel.m
+++ b/Airwallex/Card/Internal/AWXCardViewModel.m
@@ -32,6 +32,14 @@
     return self;
 }
 
+- (NSString *)ctaTitle {
+    if ([_session isKindOfClass:[AWXRecurringSession class]]) {
+        return NSLocalizedString(@"Confirm", @"Confirm button title");
+    } else {
+        return NSLocalizedString(@"Pay", @"Pay button title");
+    }
+}
+
 - (NSString *)pageName {
     return @"card_payment_view";
 }

--- a/Airwallex/CardTests/AWXCardViewModelTests.m
+++ b/Airwallex/CardTests/AWXCardViewModelTests.m
@@ -321,6 +321,16 @@
     XCTAssertEqualObjects(viewModel.additionalInfo, dict);
 }
 
+- (void)testCtaTitleWhenOneOffSession {
+    AWXCardViewModel *viewModel = [self mockOneOffViewModel];
+    XCTAssertEqualObjects(viewModel.ctaTitle, @"Pay");
+}
+
+- (void)testCtaTitleWhenRecurringSession {
+    AWXCardViewModel *viewModel = [self mockRecurringViewModel];
+    XCTAssertEqualObjects(viewModel.ctaTitle, @"Confirm");
+}
+
 - (AWXCardViewModel *)mockOneOffViewModel {
     AWXOneOffSession *session = [AWXOneOffSession new];
     return [[AWXCardViewModel alloc] initWithSession:session supportedCardSchemes:NULL];


### PR DESCRIPTION
To display 'Confirm' instead of 'Pay' as button title in recurring session.