### PR TITLE
[Mob-2055] Allow apple pay low level api Integration

### DIFF
--- a/Airwallex/ApplePay/AWXApplePayProvider.h
+++ b/Airwallex/ApplePay/AWXApplePayProvider.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
  `AWXApplePayProvider` is a provider to handle payment method with Apple Pay.
  */
 @interface AWXApplePayProvider : AWXDefaultProvider
-- (void)makePayment;
+- (void)startPayment;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Airwallex/ApplePay/AWXApplePayProvider.h
+++ b/Airwallex/ApplePay/AWXApplePayProvider.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
  `AWXApplePayProvider` is a provider to handle payment method with Apple Pay.
  */
 @interface AWXApplePayProvider : AWXDefaultProvider
-
+- (void)makePayment;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Airwallex/ApplePay/AWXApplePayProvider.m
+++ b/Airwallex/ApplePay/AWXApplePayProvider.m
@@ -38,7 +38,6 @@
         _isApplePayInitiatedDirectly = true;
         [self handleFlow];
     } else {
-        // Make error message specific to apple pay
         NSError *error = [NSError errorWithDomain:AWXSDKErrorDomain
                                              code:-1
                                          userInfo:@{NSLocalizedDescriptionKey: errorReason}];

--- a/Airwallex/ApplePay/AWXApplePayProvider.m
+++ b/Airwallex/ApplePay/AWXApplePayProvider.m
@@ -148,10 +148,7 @@
         } else {
             if (strongSelf.isApplePayInitiatedDirectly) {
                 dispatch_async(dispatch_get_main_queue(), ^{
-                    NSError *error = [NSError errorWithDomain:AWXSDKErrorDomain
-                                                         code:-1
-                                                     userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"User cancelled Apple Pay.", nil)}];
-                    [[self delegate] provider:self didCompleteWithStatus:AirwallexPaymentStatusCancel error:error];
+                    [[self delegate] provider:self didCompleteWithStatus:AirwallexPaymentStatusCancel error:nil];
                 });
             } else {
                 // The user most likely has cancelled the authorization.

--- a/Airwallex/ApplePay/Internal/AWXOneOffSession+Request.m
+++ b/Airwallex/ApplePay/Internal/AWXOneOffSession+Request.m
@@ -29,6 +29,15 @@
         request.billingContact = [self.billing convertToPaymentContact];
     }
 
+    if (!self.countryCode) {
+        if (error) {
+            *error = [NSError errorWithDomain:AWXSDKErrorDomain
+                                         code:-1
+                                     userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Missing country code in session.", nil)}];
+        }
+        return nil;
+    }
+    
     request.countryCode = self.countryCode;
     request.currencyCode = self.currency;
     request.merchantCapabilities = options.merchantCapabilities;
@@ -39,6 +48,16 @@
             *error = [NSError errorWithDomain:AWXSDKErrorDomain
                                          code:-1
                                      userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"paymentIntent cannot be nil.", nil)}];
+        }
+        return nil;
+    }
+
+    NSString *paymentIntentValidationError = [self validatePaymentIntentDataInSession:self.paymentIntent];
+    if (paymentIntentValidationError) {
+        if (error) {
+            *error = [NSError errorWithDomain:AWXSDKErrorDomain
+                                         code:-1
+                                     userInfo:@{NSLocalizedDescriptionKey: paymentIntentValidationError}];
         }
         return nil;
     }
@@ -58,4 +77,19 @@
     return request;
 }
 
+- (nullable NSString *)validatePaymentIntentDataInSession:(AWXPaymentIntent *)paymentIntent {
+    if (!paymentIntent.amount) {
+        return NSLocalizedString(@"Missing amount in PaymentIntent.", nil);
+    }
+
+    if (!paymentIntent.currency || paymentIntent.currency.length != 3) {
+        return NSLocalizedString(@"Currency code should be three-letter ISO 4217 currency code.", nil);
+    }
+
+    if (!paymentIntent.Id) {
+        return NSLocalizedString(@"Missing id in PaymentIntent.", nil);
+    }
+
+    return nil;
+}
 @end

--- a/Airwallex/ApplePayTests/AWXApplePayProviderTest.m
+++ b/Airwallex/ApplePayTests/AWXApplePayProviderTest.m
@@ -320,9 +320,9 @@
     AWXProviderDelegateSpy *delegate = [AWXProviderDelegateSpy new];
     AWXApplePayProvider *provider = [[AWXApplePayProvider alloc] initWithDelegate:delegate session:session];
     id providerSpy = OCMPartialMock(provider);
-    
+
     [provider makePayment];
-    
+
     OCMVerify(times(1), [providerSpy handleFlow]);
 }
 
@@ -332,14 +332,14 @@
     AWXProviderDelegateSpy *delegate = [AWXProviderDelegateSpy new];
     AWXApplePayProvider *provider = [[AWXApplePayProvider alloc] initWithDelegate:delegate session:session];
     id providerSpy = OCMPartialMock(provider);
-    
+
     [provider makePayment];
-    
+
     OCMVerify(never(), [providerSpy handleFlow]);
     XCTAssertEqual(delegate.lastStatus, AirwallexPaymentStatusFailure);
     XCTAssertEqualObjects(delegate.lastStatusError, [NSError errorWithDomain:AWXSDKErrorDomain
-                                                                 code:-1
-                                                             userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Unsupported session type.", nil)}]);
+                                                                        code:-1
+                                                                    userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Unsupported session type.", nil)}]);
 }
 
 - (void)testMakePaymentWithMissingApplePayOptionsReturnsError {
@@ -348,14 +348,14 @@
     AWXProviderDelegateSpy *delegate = [AWXProviderDelegateSpy new];
     AWXApplePayProvider *provider = [[AWXApplePayProvider alloc] initWithDelegate:delegate session:session];
     id providerSpy = OCMPartialMock(provider);
-    
+
     [provider makePayment];
-    
+
     OCMVerify(never(), [providerSpy handleFlow]);
     XCTAssertEqual(delegate.lastStatus, AirwallexPaymentStatusFailure);
     XCTAssertEqualObjects(delegate.lastStatusError, [NSError errorWithDomain:AWXSDKErrorDomain
-                                                                 code:-1
-                                                             userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Missing Apple Pay options in session.", nil)}]);
+                                                                        code:-1
+                                                                    userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Missing Apple Pay options in session.", nil)}]);
 }
 
 - (void)testMakePaymentWithUnsupportedCapabilitiesReturnsError {
@@ -368,14 +368,14 @@
     AWXProviderDelegateSpy *delegate = [AWXProviderDelegateSpy new];
     AWXApplePayProvider *provider = [[AWXApplePayProvider alloc] initWithDelegate:delegate session:session];
     id providerSpy = OCMPartialMock(provider);
-    
+
     [provider makePayment];
-    
+
     OCMVerify(never(), [providerSpy handleFlow]);
     XCTAssertEqual(delegate.lastStatus, AirwallexPaymentStatusFailure);
     XCTAssertEqualObjects(delegate.lastStatusError, [NSError errorWithDomain:AWXSDKErrorDomain
-                                                                 code:-1
-                                                             userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Payment cannot be processed via Apple pay using the specified networks and capabilities.", nil)}]);
+                                                                        code:-1
+                                                                    userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Payment cannot be processed via Apple pay using the specified networks and capabilities.", nil)}]);
 }
 
 - (AWXOneOffSession *)makeSession {

--- a/Airwallex/ApplePayTests/AWXApplePayProviderTest.m
+++ b/Airwallex/ApplePayTests/AWXApplePayProviderTest.m
@@ -376,7 +376,7 @@
     [self prepareAuthorizationControllerMock:nil billingPayload:nil result:nil endImmediately:YES];
 
     AWXApplePayProvider *provider = [[AWXApplePayProvider alloc] initWithDelegate:delegate session:session];
-    
+
     [provider startPayment];
 
     [self waitForExpectationsWithTimeout:1 handler:nil];
@@ -390,9 +390,13 @@
 
 - (AWXOneOffSession *)makeSession {
     AWXOneOffSession *session = [AWXOneOffSession new];
-
+    session.countryCode = @"AU";
+    
     AWXPaymentIntent *intent = [AWXPaymentIntent new];
     session.paymentIntent = intent;
+    intent.Id = @"PaymentIntentId";
+    intent.currency = @"AUD";
+    intent.amount = [[NSDecimalNumber alloc] initWithInt:50];
     intent.customerId = @"customerId";
 
     AWXPlaceDetails *billing = [AWXPlaceDetails new];

--- a/Airwallex/ApplePayTests/AWXApplePayProviderTest.m
+++ b/Airwallex/ApplePayTests/AWXApplePayProviderTest.m
@@ -366,11 +366,11 @@
                                                                     userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Payment not supported via Apple pay.", nil)}]);
 }
 
-- (void)testStartPaymentWhenCancelledReturnsError {
+- (void)testStartPaymentWhenCancelledReturnsCancelStatus {
     AWXOneOffSession *session = [self makeSession];
 
     AWXProviderDelegateSpy *delegate = [AWXProviderDelegateSpy new];
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Expect completeWithStatus to be called"];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Expect completeWithStatus to be called with cancel status"];
     delegate.statusExpectation = expectation;
 
     [self prepareAuthorizationControllerMock:nil billingPayload:nil result:nil endImmediately:YES];
@@ -383,9 +383,7 @@
 
     XCTAssertEqual(delegate.providerDidCompleteWithStatusCount, 1);
     XCTAssertEqual(delegate.lastStatus, AirwallexPaymentStatusCancel);
-    XCTAssertEqualObjects(delegate.lastStatusError, [NSError errorWithDomain:AWXSDKErrorDomain
-                                                                        code:-1
-                                                                    userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"User cancelled Apple Pay.", nil)}]);
+    XCTAssertNil(delegate.lastStatusError);
 }
 
 - (AWXOneOffSession *)makeSession {

--- a/Airwallex/ApplePayTests/AWXOneOffSessionRequestTest.m
+++ b/Airwallex/ApplePayTests/AWXOneOffSessionRequestTest.m
@@ -36,6 +36,7 @@
 
     AWXPaymentIntent *intent = [AWXPaymentIntent new];
     session.paymentIntent = intent;
+    intent.Id = @"PaymentIntentId";
     intent.currency = @"AUD";
     intent.amount = [[NSDecimalNumber alloc] initWithInt:50];
 
@@ -70,6 +71,7 @@
 
     AWXPaymentIntent *intent = [AWXPaymentIntent new];
     session.paymentIntent = intent;
+    intent.Id = @"PaymentIntentId";
     intent.currency = @"AUD";
     intent.amount = [[NSDecimalNumber alloc] initWithInt:50];
 
@@ -110,6 +112,106 @@
 
     XCTAssertNil(request);
     XCTAssertNotNil(error);
+}
+
+- (void)testMakePaymentRequestWithMissingCountryCodeInSession {
+    AWXOneOffSession *session = [AWXOneOffSession new];
+    session.applePayOptions = [self makeOptions:nil];
+
+    AWXPaymentIntent *intent = [AWXPaymentIntent new];
+    session.paymentIntent = intent;
+    intent.Id = @"PaymentIntentId";
+    intent.currency = @"AUD";
+    intent.amount = [[NSDecimalNumber alloc] initWithInt:50];
+    
+    NSError *error;
+    PKPaymentRequest *request = [session makePaymentRequestOrError:&error];
+
+    XCTAssertNil(request);
+    XCTAssertEqualObjects(error, [NSError errorWithDomain:AWXSDKErrorDomain
+                                                     code:-1
+                                                 userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Missing country code in session.", nil)}]);
+}
+
+- (void)testMakePaymentRequestWithMissingAmountInIntent {
+    AWXOneOffSession *session = [AWXOneOffSession new];
+    session.countryCode = @"AU";
+    session.applePayOptions = [self makeOptions:nil];
+
+    AWXPaymentIntent *intent = [AWXPaymentIntent new];
+    session.paymentIntent = intent;
+    intent.Id = @"PaymentIntentId";
+    intent.currency = @"AUD";
+
+    NSError *error;
+    PKPaymentRequest *request = [session makePaymentRequestOrError:&error];
+
+    XCTAssertNil(request);
+    XCTAssertEqualObjects(error, [NSError errorWithDomain:AWXSDKErrorDomain
+                                                     code:-1
+                                                 userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Missing amount in PaymentIntent.", nil)}]);
+}
+
+- (void)testMakePaymentRequestWithMissingIdInIntent {
+    AWXOneOffSession *session = [AWXOneOffSession new];
+    session.countryCode = @"AU";
+    session.applePayOptions = [self makeOptions:nil];
+
+    AWXPaymentIntent *intent = [AWXPaymentIntent new];
+    session.paymentIntent = intent;
+    intent.currency = @"AUD";
+    intent.amount = [[NSDecimalNumber alloc] initWithInt:50];
+
+    NSError *error;
+    PKPaymentRequest *request = [session makePaymentRequestOrError:&error];
+
+    XCTAssertNil(request);
+    XCTAssertEqualObjects(error, [NSError errorWithDomain:AWXSDKErrorDomain
+                                                     code:-1
+                                                 userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Missing id in PaymentIntent.", nil)}]);
+}
+
+- (void)testMakePaymentRequestWithMissingCurrencyCodeInIntent {
+    AWXOneOffSession *session = [AWXOneOffSession new];
+    session.countryCode = @"AU";
+    session.applePayOptions = [self makeOptions:nil];
+
+    AWXPaymentIntent *intent = [AWXPaymentIntent new];
+    intent.Id = @"PaymentIntentId";
+    intent.amount = [[NSDecimalNumber alloc] initWithInt:50];
+    session.paymentIntent = intent;
+
+    intent.amount = [[NSDecimalNumber alloc] initWithInt:50];
+
+    NSError *error;
+    PKPaymentRequest *request = [session makePaymentRequestOrError:&error];
+
+    XCTAssertNil(request);
+    XCTAssertEqualObjects(error, [NSError errorWithDomain:AWXSDKErrorDomain
+                                                     code:-1
+                                                 userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Currency code should be three-letter ISO 4217 currency code.", nil)}]);
+}
+
+- (void)testMakePaymentRequestWithCurrencyCodeOfInvalidLengthInIntent {
+    AWXOneOffSession *session = [AWXOneOffSession new];
+    session.countryCode = @"AU";
+    session.applePayOptions = [self makeOptions:nil];
+
+    AWXPaymentIntent *intent = [AWXPaymentIntent new];
+    intent.Id = @"PaymentIntentId";
+    intent.currency = @"AU";
+    intent.amount = [[NSDecimalNumber alloc] initWithInt:50];
+    session.paymentIntent = intent;
+
+    intent.amount = [[NSDecimalNumber alloc] initWithInt:50];
+
+    NSError *error;
+    PKPaymentRequest *request = [session makePaymentRequestOrError:&error];
+
+    XCTAssertNil(request);
+    XCTAssertEqualObjects(error, [NSError errorWithDomain:AWXSDKErrorDomain
+                                                     code:-1
+                                                 userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Currency code should be three-letter ISO 4217 currency code.", nil)}]);
 }
 
 - (AWXApplePayOptions *)makeOptions:(nullable NSArray<PKPaymentSummaryItem *> *)items {

--- a/Airwallex/CardTests/AWXCardProviderTests.m
+++ b/Airwallex/CardTests/AWXCardProviderTests.m
@@ -57,9 +57,9 @@
     session.autoCapture = YES;
     AWXCardProvider *provider = [[AWXCardProvider alloc] initWithDelegate:spy session:session];
     id providerSpy = OCMPartialMock(provider);
-    
+
     OCMStub([providerSpy setDevice:([OCMArg invokeBlockWithArgs:device, nil])]);
-    
+
     [provider confirmPaymentIntentWithPaymentConsentId:@"consentID"];
 
     OCMVerify(times(1), [client send:[OCMArg checkWithBlock:^BOOL(id obj) {

--- a/Airwallex/CoreTests/AWXDefaultProviderTest.m
+++ b/Airwallex/CoreTests/AWXDefaultProviderTest.m
@@ -251,12 +251,12 @@ NSString *const kMockKey = @"MOCK";
     id mockHandler = OCMClassMock([AWXNextActionHandler class]);
     OCMStub([mockHandler initWithDelegate:[OCMArg any] session:[OCMArg any]]).andReturn(mockHandler);
     OCMStub([mockHandler alloc]).andReturn(mockHandler);
-    
+
     NSData *confirmResponseData = [NSJSONSerialization dataWithJSONObject:[AWXTestUtils jsonNamed:@"ConfirmPaymentIntent"] options:0 error:nil];
     AWXResponse *response = [AWXConfirmPaymentIntentResponse parse:confirmResponseData];
     AWXConfirmPaymentIntentResponse *confirmResponse = (AWXConfirmPaymentIntentResponse *)response;
     [provider completeWithResponse:confirmResponse error:nil];
-    
+
     OCMVerify(times(1), [mockHandler handleNextAction:[OCMArg any]]);
 }
 

--- a/Airwallex/CoreTests/AWXNextActionHandlerTest.m
+++ b/Airwallex/CoreTests/AWXNextActionHandlerTest.m
@@ -6,8 +6,8 @@
 //  Copyright © 2024 Airwallex. All rights reserved.
 //
 
-#import "AWXDefaultActionProvider.h"
 #import "AWXNextActionHandler.h"
+#import "AWXDefaultActionProvider.h"
 #import "AWXProviderDelegateSpy.h"
 #import "AWXSession.h"
 #import <OCMock/OCMock.h>
@@ -24,12 +24,12 @@
 
     OCMStub([mockProvider initWithDelegate:[OCMArg any] session:[OCMArg any]]).andReturn(mockProvider);
     OCMStub([mockProvider alloc]).andReturn(mockProvider);
-    
+
     AWXProviderDelegateSpy *spy = [AWXProviderDelegateSpy new];
     AWXOneOffSession *session = [AWXOneOffSession new];
     NSDictionary *dict = [NSDictionary dictionaryWithObjectsAndKeys:@"next", @"type", nil];
     AWXConfirmPaymentNextAction *nextAction = [AWXConfirmPaymentNextAction decodeFromJSON:dict];
-    
+
     AWXNextActionHandler *handler = [[AWXNextActionHandler alloc] initWithDelegate:spy session:session];
     [handler handleNextAction:nextAction];
     OCMVerify(times(1), [mockProvider handleNextAction:nextAction]);
@@ -40,7 +40,7 @@
     AWXOneOffSession *session = [AWXOneOffSession new];
     NSDictionary *dict = [NSDictionary dictionaryWithObjectsAndKeys:@"redirect", @"type", nil];
     AWXConfirmPaymentNextAction *nextAction = [AWXConfirmPaymentNextAction decodeFromJSON:dict];
-    
+
     AWXNextActionHandler *handler = [[AWXNextActionHandler alloc] initWithDelegate:mockDelegate session:session];
     [handler handleNextAction:nextAction];
     OCMVerify(times(1), [mockDelegate provider:[OCMArg any] shouldPresentViewController:[OCMArg any] forceToDismiss:YES withAnimation:YES]);

--- a/Airwallex/CoreTests/AWXProviderDelegateEmpty.m
+++ b/Airwallex/CoreTests/AWXProviderDelegateEmpty.m
@@ -10,19 +10,19 @@
 
 @implementation AWXProviderDelegateEmpty
 
-- (void)provider:(nonnull AWXDefaultProvider *)provider didCompleteWithStatus:(AirwallexPaymentStatus)status error:(nullable NSError *)error { 
+- (void)provider:(nonnull AWXDefaultProvider *)provider didCompleteWithStatus:(AirwallexPaymentStatus)status error:(nullable NSError *)error {
     // no op
 }
 
-- (void)provider:(nonnull AWXDefaultProvider *)provider didInitializePaymentIntentId:(nonnull NSString *)paymentIntentId { 
+- (void)provider:(nonnull AWXDefaultProvider *)provider didInitializePaymentIntentId:(nonnull NSString *)paymentIntentId {
     // no op
 }
 
-- (void)providerDidEndRequest:(nonnull AWXDefaultProvider *)provider { 
+- (void)providerDidEndRequest:(nonnull AWXDefaultProvider *)provider {
     // no op
 }
 
-- (void)providerDidStartRequest:(nonnull AWXDefaultProvider *)provider { 
+- (void)providerDidStartRequest:(nonnull AWXDefaultProvider *)provider {
     // no op
 }
 

--- a/Examples/Examples/AirwallexExamplesKeys.h
+++ b/Examples/Examples/AirwallexExamplesKeys.h
@@ -16,6 +16,7 @@ static NSString *const kCachedCheckoutMode = @"kCachedCheckoutMode";
 static NSString *const kCachedNextTriggerBy = @"kCachedNextTriggerBy";
 static NSString *const kCachedRequiresCVC = @"kCachedRequiresCVC";
 static NSString *const kCachedAutoCapture = @"kCachedAutoCapture";
+static NSString *const kCachedApplePayMethodOnly = @"kCachedApplePayMethodOnly";
 static NSString *const kCachedCustomerID = @"kCachedCustomerID";
 static NSString *const kCachedApiKey = @"kCachedApiKey";
 static NSString *const kCachedClientId = @"kCachedClientId";
@@ -37,6 +38,7 @@ typedef NS_ENUM(NSInteger, AirwallexCheckoutMode) {
 @property (nonatomic) AirwallexNextTriggerByType nextTriggerByType;
 @property (nonatomic) BOOL requireCVC;
 @property (nonatomic) BOOL autoCapture;
+@property (nonatomic) BOOL applePayMethodOnly;
 @property (nonatomic, strong, nullable) NSString *customerId;
 @property (nonatomic, strong) NSString *apiKey;
 @property (nonatomic, strong) NSString *clientId;

--- a/Examples/Examples/AirwallexExamplesKeys.m
+++ b/Examples/Examples/AirwallexExamplesKeys.m
@@ -58,6 +58,7 @@
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:kCachedCountryCode];
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:kCachedReturnURL];
     [[NSUserDefaults standardUserDefaults] setBool:YES forKey:kCachedAutoCapture];
+    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:kCachedApplePayMethodOnly];
     [[NSUserDefaults standardUserDefaults] synchronize];
 
     [self syncKeys];
@@ -70,6 +71,7 @@
     self.nextTriggerByType = [userDefaults integerForKey:kCachedNextTriggerBy];
     self.requireCVC = [userDefaults boolForKey:kCachedRequiresCVC];
     self.autoCapture = [userDefaults boolForKey:kCachedAutoCapture];
+    self.applePayMethodOnly = [userDefaults boolForKey:kCachedApplePayMethodOnly];
     self.customerId = [userDefaults stringForKey:kCachedCustomerID];
 
     NSString *cachedApiKey = [userDefaults stringForKey:kCachedApiKey];
@@ -106,6 +108,11 @@
 - (void)setAutoCapture:(BOOL)autoCapture {
     _autoCapture = autoCapture;
     [[NSUserDefaults standardUserDefaults] setBool:autoCapture forKey:kCachedAutoCapture];
+}
+
+- (void)setApplePayMethodOnly:(BOOL)applePayMethodOnly {
+    _applePayMethodOnly = applePayMethodOnly;
+    [[NSUserDefaults standardUserDefaults] setBool:applePayMethodOnly forKey:kCachedApplePayMethodOnly];
 }
 
 - (void)setCustomerId:(nullable NSString *)customerId {

--- a/Examples/Examples/Cart/CartViewController.m
+++ b/Examples/Examples/Cart/CartViewController.m
@@ -14,10 +14,11 @@
 #import "ShippingCell.h"
 #import "TotalCell.h"
 #import "UIViewController+Utils.h"
+#import <Airwallex/ApplePay.h>
 #import <Airwallex/Core.h>
 #import <SafariServices/SFSafariViewController.h>
 
-@interface CartViewController ()<UITableViewDelegate, UITableViewDataSource, AWXShippingViewControllerDelegate, AWXPaymentResultDelegate>
+@interface CartViewController ()<UITableViewDelegate, UITableViewDataSource, AWXShippingViewControllerDelegate, AWXPaymentResultDelegate, AWXProviderDelegate>
 
 @property (nonatomic, strong) UIActivityIndicatorView *activityIndicator;
 @property (strong, nonatomic) IBOutlet UILabel *titleLabel;
@@ -26,6 +27,7 @@
 @property (strong, nonatomic) NSMutableArray *products;
 @property (strong, nonatomic) AWXPlaceDetails *shipping;
 @property (strong, nonatomic) AWXPaymentIntent *paymentIntent;
+@property (strong, nonatomic) AWXApplePayProvider *applePayProvider;
 
 @end
 
@@ -114,6 +116,11 @@
 
     self.checkoutButton.enabled = self.shipping != nil && amount.doubleValue > 0 && currency.length > 0 && countryCode.length > 0 && returnUrl.length > 0;
 
+    NSString *checkoutTitle = @"Checkout";
+    if ([[NSUserDefaults standardUserDefaults] boolForKey:kCachedApplePayMethodOnly]) {
+        checkoutTitle = @"Pay";
+    }
+    [self.checkoutButton setTitle:checkoutTitle forState:UIControlStateNormal];
     [self.tableView reloadData];
 }
 
@@ -258,7 +265,12 @@
         } else if (_customerSecret) {
             [AWXAPIClientConfiguration sharedConfiguration].clientSecret = _customerSecret;
         }
-        [strongSelf showPaymentFlowWithPaymentIntent:_paymentIntent];
+
+        if ([[NSUserDefaults standardUserDefaults] boolForKey:kCachedApplePayMethodOnly]) {
+            [strongSelf initiateApplePaymentFlowWithPaymentIntent:_paymentIntent];
+        } else {
+            [strongSelf showPaymentFlowWithPaymentIntent:_paymentIntent];
+        }
     });
 }
 
@@ -330,6 +342,18 @@
     context.delegate = self;
     context.session = session;
     [context presentPaymentFlowFrom:self];
+}
+
+#pragma mark - Initiate Apple Pay Flow
+- (void)initiateApplePaymentFlowWithPaymentIntent:(nullable AWXPaymentIntent *)paymentIntent {
+    self.paymentIntent = paymentIntent;
+    // Step 3: Create session
+    AWXSession *session = [self createSession:paymentIntent];
+
+    // Step 4: Present payment flow
+    AWXApplePayProvider *provider = [[AWXApplePayProvider alloc] initWithDelegate:self session:session];
+    [provider makePayment];
+    _applePayProvider = provider;
 }
 
 #pragma mark - Show Payment Result
@@ -453,6 +477,36 @@
                                            break;
                                        }
                                    }];
+}
+
+#pragma mark - AWXProviderDelegate
+
+- (void)provider:(nonnull AWXDefaultProvider *)provider didCompleteWithStatus:(AirwallexPaymentStatus)status error:(nullable NSError *)error {
+    switch (status) {
+    case AirwallexPaymentStatusSuccess:
+        [self showPaymentSuccess];
+        break;
+    case AirwallexPaymentStatusFailure:
+        [self showPaymentFailure:error];
+        break;
+    case AirwallexPaymentStatusCancel:
+        [self showPaymentCancel];
+        break;
+    default:
+        break;
+    }
+}
+
+- (void)provider:(nonnull AWXDefaultProvider *)provider didInitializePaymentIntentId:(nonnull NSString *)paymentIntentId {
+    NSLog(@"didInitializePaymentIntentId: %@", paymentIntentId);
+}
+
+- (void)providerDidEndRequest:(nonnull AWXDefaultProvider *)provider {
+    NSLog(@"providerDidEndRequest");
+}
+
+- (void)providerDidStartRequest:(nonnull AWXDefaultProvider *)provider {
+    NSLog(@"providerDidStartRequest");
 }
 
 @end

--- a/Examples/Examples/Cart/CartViewController.m
+++ b/Examples/Examples/Cart/CartViewController.m
@@ -352,7 +352,7 @@
 
     // Step 4: Present payment flow
     AWXApplePayProvider *provider = [[AWXApplePayProvider alloc] initWithDelegate:self session:session];
-    [provider makePayment];
+    [provider startPayment];
     _applePayProvider = provider;
 }
 

--- a/Examples/Examples/Cart/OptionsViewController.m
+++ b/Examples/Examples/Cart/OptionsViewController.m
@@ -37,6 +37,7 @@
 @property (weak, nonatomic) IBOutlet OptionButton *nextTriggerByBtn;
 @property (weak, nonatomic) IBOutlet UISwitch *cvcSwitch;
 @property (weak, nonatomic) IBOutlet UISwitch *autoCaptureSwitch;
+@property (weak, nonatomic) IBOutlet UISwitch *applePayOnlySwitch;
 @property (weak, nonatomic) IBOutlet UITextField *customerIdTextField;
 @property (weak, nonatomic) IBOutlet UIButton *clearCustomerIdButton;
 
@@ -190,6 +191,10 @@
     [AirwallexExamplesKeys shared].autoCapture = self.autoCaptureSwitch.isOn;
 }
 
+- (IBAction)applePayOnlySwitchPressed:(id)sender {
+    [AirwallexExamplesKeys shared].applePayMethodOnly = self.applePayOnlySwitch.isOn;
+}
+
 - (IBAction)generateCustomer:(id)sender {
     [self.activityIndicator startAnimating];
     __weak __typeof(self) weakSelf = self;
@@ -275,6 +280,9 @@
 
     BOOL autoCapture = [AirwallexExamplesKeys shared].autoCapture;
     self.autoCaptureSwitch.on = autoCapture;
+
+    BOOL applePayMethodOnly = [AirwallexExamplesKeys shared].applePayMethodOnly;
+    self.applePayOnlySwitch.on = applePayMethodOnly;
 
     self.customerIdTextField.enabled = NO;
     NSString *customerId = [AirwallexExamplesKeys shared].customerId;

--- a/Examples/Examples/Demo/WebViewController.m
+++ b/Examples/Examples/Demo/WebViewController.m
@@ -42,8 +42,8 @@
         self.webView.navigationDelegate = self;
         self.webView.UIDelegate = self;
         [self.webView loadRequest:requeset];
-        //设置ua会造成微信支付 cancel 无法返回
-        //        [self setWebViewUA];
+        // 设置ua会造成微信支付 cancel 无法返回
+        //         [self setWebViewUA];
     }
 }
 

--- a/Examples/Examples/Resources/Base.lproj/Main.storyboard
+++ b/Examples/Examples/Resources/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="pG9-fq-6li">
-    <device id="retina3_5" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="pG9-fq-6li">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -15,18 +15,18 @@
             <objects>
                 <viewController id="BYZ-38-t0r" userLabel="Cart" customClass="CartViewController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="eCS-DG-9uu">
-                                <rect key="frame" x="0.0" y="44" width="320" height="359"/>
+                                <rect key="frame" x="0.0" y="103" width="393" height="634"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <view key="tableHeaderView" contentMode="scaleToFill" id="wBh-JP-Meb">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="80"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="393" height="80"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="My cart" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="emf-Qn-Zl3">
-                                            <rect key="frame" x="16" y="16" width="288" height="48"/>
+                                            <rect key="frame" x="16" y="16" width="361" height="48"/>
                                             <fontDescription key="fontDescription" type="boldSystem" pointSize="27"/>
                                             <color key="textColor" name="Black Text Color"/>
                                             <nil key="highlightedColor"/>
@@ -42,29 +42,29 @@
                                 </view>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="ShippingCell" id="L2w-l6-jwz" customClass="ShippingCell">
-                                        <rect key="frame" x="0.0" y="129.5" width="320" height="59"/>
+                                        <rect key="frame" x="0.0" y="135.33333206176758" width="393" height="59"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="L2w-l6-jwz" id="aBr-fF-Llt">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="59"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="393" height="59"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Shipping" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vh8-dj-yqR">
-                                                    <rect key="frame" x="16" y="20" width="60.5" height="18"/>
+                                                    <rect key="frame" x="15.999999999999996" y="20" width="60.666666666666657" height="18"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                     <color key="textColor" name="Grey Text Color"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Enter shipping information" textAlignment="right" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kRL-Mh-vjv">
-                                                    <rect key="frame" x="92.5" y="20" width="195.5" height="18"/>
+                                                    <rect key="frame" x="92.666666666666657" y="20" width="268.33333333333337" height="18"/>
                                                     <fontDescription key="fontDescription" type="system" weight="medium" pointSize="15"/>
                                                     <color key="textColor" name="Placeholder Color"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="right" translatesAutoresizingMaskIntoConstraints="NO" id="BbU-Q7-jOG">
-                                                    <rect key="frame" x="296" y="21" width="16" height="16"/>
+                                                    <rect key="frame" x="369" y="21" width="16" height="16"/>
                                                 </imageView>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JqI-fU-V83" userLabel="Line">
-                                                    <rect key="frame" x="0.0" y="58" width="320" height="1"/>
+                                                    <rect key="frame" x="0.0" y="58" width="393" height="1"/>
                                                     <color key="backgroundColor" systemColor="separatorColor"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="1" id="HRO-Z6-InO"/>
@@ -95,32 +95,32 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="ProductCell" rowHeight="155" id="P5K-v1-gGW" customClass="ProductCell">
-                                        <rect key="frame" x="0.0" y="188.5" width="320" height="155"/>
+                                        <rect key="frame" x="0.0" y="194.33333206176758" width="393" height="155"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="P5K-v1-gGW" id="ye2-6z-VD7">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="155"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="393" height="155"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="AirPods Pro" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nwS-kV-rcA">
-                                                    <rect key="frame" x="16" y="16" width="211.5" height="21"/>
+                                                    <rect key="frame" x="16" y="16" width="284.66666666666669" height="21"/>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                                     <color key="textColor" name="Black Text Color"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$399.00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="irC-v0-rxQ">
-                                                    <rect key="frame" x="243.5" y="17.5" width="60.5" height="18"/>
+                                                    <rect key="frame" x="316.66666666666669" y="17.666666666666668" width="60.333333333333314" height="18.000000000000004"/>
                                                     <fontDescription key="fontDescription" type="system" weight="medium" pointSize="15"/>
                                                     <color key="textColor" name="Black Text Color"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="251" text="Free engraving x 1" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Rw-H1-zCS">
-                                                    <rect key="frame" x="16" y="53" width="207" height="18"/>
+                                                    <rect key="frame" x="16" y="53" width="280" height="18"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                     <color key="textColor" name="Grey Text Color"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yD2-fF-CeK">
-                                                    <rect key="frame" x="239" y="45.5" width="65" height="33"/>
+                                                    <rect key="frame" x="312" y="45.666666666666664" width="65" height="32.999999999999993"/>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                                     <state key="normal" title="Remove"/>
                                                     <connections>
@@ -128,7 +128,7 @@
                                                     </connections>
                                                 </button>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5HX-Cc-5H1" userLabel="Line">
-                                                    <rect key="frame" x="16" y="87" width="288" height="1"/>
+                                                    <rect key="frame" x="16" y="87" width="361" height="1"/>
                                                     <color key="backgroundColor" systemColor="separatorColor"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="1" id="lot-gG-dFc"/>
@@ -162,45 +162,45 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="TotalCell" rowHeight="214" id="KOI-Zh-6jg" customClass="TotalCell">
-                                        <rect key="frame" x="0.0" y="343.5" width="320" height="214"/>
+                                        <rect key="frame" x="0.0" y="349.33333206176758" width="393" height="214"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="KOI-Zh-6jg" id="gtZ-fH-PXU">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="214"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="393" height="214"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Subtotal" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uVR-Bl-NT8">
-                                                    <rect key="frame" x="16" y="16" width="216.5" height="17"/>
+                                                    <rect key="frame" x="16" y="16" width="289.66666666666669" height="17"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <color key="textColor" name="Grey Text Color"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$868.00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r9G-2V-mGn">
-                                                    <rect key="frame" x="248.5" y="16" width="55.5" height="17"/>
+                                                    <rect key="frame" x="321.66666666666669" y="16" width="55.333333333333314" height="17"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <color key="textColor" name="Black Text Color"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xp4-as-KUI" userLabel="Line">
-                                                    <rect key="frame" x="16" y="49" width="288" height="1"/>
+                                                    <rect key="frame" x="16" y="49" width="361" height="1"/>
                                                     <color key="backgroundColor" name="Line Color"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="1" id="P1I-zy-b1g"/>
                                                     </constraints>
                                                 </view>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Total" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="axE-HU-4dc">
-                                                    <rect key="frame" x="16" y="70" width="212.5" height="17"/>
+                                                    <rect key="frame" x="16" y="70" width="285.66666666666669" height="17"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <color key="textColor" name="Black Text Color"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$868.00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="t5E-nF-vKe">
-                                                    <rect key="frame" x="248.5" y="70" width="55.5" height="17"/>
+                                                    <rect key="frame" x="321.66666666666669" y="70" width="55.333333333333314" height="17"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <color key="textColor" name="Black Text Color"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lco-dt-qnc" userLabel="Line">
-                                                    <rect key="frame" x="0.0" y="107" width="320" height="1"/>
+                                                    <rect key="frame" x="0.0" y="107" width="393" height="1"/>
                                                     <color key="backgroundColor" systemColor="separatorColor"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="1" id="JaA-u6-Xjy"/>
@@ -244,7 +244,7 @@
                                 </connections>
                             </tableView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Uad-jD-BvN" customClass="AWXActionButton">
-                                <rect key="frame" x="16" y="435" width="288" height="29"/>
+                                <rect key="frame" x="16" y="769" width="361" height="33"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <state key="normal" title="Checkout">
@@ -292,11 +292,11 @@
             <objects>
                 <viewController id="7Ab-n5-deV" customClass="InputViewController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="NlY-P6-FYU">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Web‘s url" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="JNL-Sa-Ann">
-                                <rect key="frame" x="20" y="104" width="280" height="44"/>
+                                <rect key="frame" x="20" y="163" width="353" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="Pdu-OK-fXh"/>
                                 </constraints>
@@ -304,7 +304,7 @@
                                 <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="URL"/>
                             </textField>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Referer" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="5oc-v0-fKZ">
-                                <rect key="frame" x="20" y="168" width="280" height="44"/>
+                                <rect key="frame" x="20" y="227" width="353" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="zfJ-zM-HCT"/>
                                 </constraints>
@@ -312,7 +312,7 @@
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qBM-wU-dJa" customClass="AWXActionButton">
-                                <rect key="frame" x="20" y="242" width="280" height="29"/>
+                                <rect key="frame" x="20" y="301" width="353" height="33"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                 <state key="normal" title="Launch">
@@ -355,29 +355,29 @@
             <objects>
                 <viewController id="VhN-Ut-ggN" userLabel="WeChatPay" customClass="WechatPayViewController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="gCp-cK-47s">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8MJ-m3-MiG">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
+                                <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Lz1-eN-G5i">
-                                        <rect key="frame" x="0.0" y="0.0" width="320" height="744"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="393" height="748"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="gO6-Ij-JSn">
-                                                <rect key="frame" x="16" y="16" width="288" height="645"/>
+                                                <rect key="frame" x="16" y="16" width="361" height="649"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="cs3-pf-M2O">
-                                                        <rect key="frame" x="0.0" y="0.0" width="288" height="68"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="361" height="68"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="appId" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="98O-Ym-l1r">
-                                                                <rect key="frame" x="0.0" y="0.0" width="288" height="24"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="361" height="24"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                                 <color key="textColor" name="Black Text Color"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="wx4c86d73fe4f82431" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="wo6-Ql-fyB">
-                                                                <rect key="frame" x="0.0" y="34" width="288" height="34"/>
+                                                                <rect key="frame" x="0.0" y="34" width="361" height="34"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="34" id="dc8-PF-Zzc"/>
                                                                 </constraints>
@@ -387,16 +387,16 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="4bK-wW-XBC">
-                                                        <rect key="frame" x="0.0" y="88" width="288" height="68"/>
+                                                        <rect key="frame" x="0.0" y="88" width="361" height="68"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="nonceStr" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4sB-q1-6fr">
-                                                                <rect key="frame" x="0.0" y="0.0" width="288" height="24"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="361" height="24"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                                 <color key="textColor" name="Black Text Color"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="mh1-Za-kDK">
-                                                                <rect key="frame" x="0.0" y="34" width="288" height="34"/>
+                                                                <rect key="frame" x="0.0" y="34" width="361" height="34"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="34" id="pYx-ln-BB0"/>
                                                                 </constraints>
@@ -406,16 +406,16 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="T6F-pX-Fw1">
-                                                        <rect key="frame" x="0.0" y="176" width="288" height="68"/>
+                                                        <rect key="frame" x="0.0" y="176" width="361" height="68"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="package" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2bO-y2-Mek">
-                                                                <rect key="frame" x="0.0" y="0.0" width="288" height="24"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="361" height="24"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                                 <color key="textColor" name="Black Text Color"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="ht6-Wi-z3f">
-                                                                <rect key="frame" x="0.0" y="34" width="288" height="34"/>
+                                                                <rect key="frame" x="0.0" y="34" width="361" height="34"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="34" id="9ys-Hj-Byp"/>
                                                                 </constraints>
@@ -425,16 +425,16 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="33O-Xg-lfu">
-                                                        <rect key="frame" x="0.0" y="264" width="288" height="68"/>
+                                                        <rect key="frame" x="0.0" y="264" width="361" height="68"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="partnerId" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Spw-GV-9t0">
-                                                                <rect key="frame" x="0.0" y="0.0" width="288" height="24"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="361" height="24"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                                 <color key="textColor" name="Black Text Color"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="Uh7-Fw-nfG">
-                                                                <rect key="frame" x="0.0" y="34" width="288" height="34"/>
+                                                                <rect key="frame" x="0.0" y="34" width="361" height="34"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="34" id="hqe-jx-4cu"/>
                                                                 </constraints>
@@ -444,16 +444,16 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="GlL-0b-bMo">
-                                                        <rect key="frame" x="0.0" y="352" width="288" height="68"/>
+                                                        <rect key="frame" x="0.0" y="352" width="361" height="68"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="prepayId" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8Qd-2z-N6m">
-                                                                <rect key="frame" x="0.0" y="0.0" width="288" height="24"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="361" height="24"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                                 <color key="textColor" name="Black Text Color"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="AmB-xN-PTN">
-                                                                <rect key="frame" x="0.0" y="34" width="288" height="34"/>
+                                                                <rect key="frame" x="0.0" y="34" width="361" height="34"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="34" id="KAS-HR-2kT"/>
                                                                 </constraints>
@@ -463,16 +463,16 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="H57-hO-kii">
-                                                        <rect key="frame" x="0.0" y="440" width="288" height="68"/>
+                                                        <rect key="frame" x="0.0" y="440" width="361" height="68"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="sign" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UOV-bw-6j4">
-                                                                <rect key="frame" x="0.0" y="0.0" width="288" height="24"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="361" height="24"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                                 <color key="textColor" name="Black Text Color"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="vDS-sq-2tg">
-                                                                <rect key="frame" x="0.0" y="34" width="288" height="34"/>
+                                                                <rect key="frame" x="0.0" y="34" width="361" height="34"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="34" id="K9r-1z-OlI"/>
                                                                 </constraints>
@@ -482,16 +482,16 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="bcf-fM-CRT">
-                                                        <rect key="frame" x="0.0" y="528" width="288" height="68"/>
+                                                        <rect key="frame" x="0.0" y="528" width="361" height="68"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="timeStamp" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zd9-eM-Dg1">
-                                                                <rect key="frame" x="0.0" y="0.0" width="288" height="24"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="361" height="24"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                                 <color key="textColor" name="Black Text Color"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="mL2-Av-Ir3">
-                                                                <rect key="frame" x="0.0" y="34" width="288" height="34"/>
+                                                                <rect key="frame" x="0.0" y="34" width="361" height="34"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="34" id="YQU-Mn-88J"/>
                                                                 </constraints>
@@ -501,7 +501,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ag1-gb-xwT" customClass="AWXActionButton">
-                                                        <rect key="frame" x="0.0" y="616" width="288" height="29"/>
+                                                        <rect key="frame" x="0.0" y="616" width="361" height="33"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                         <state key="normal" title="Checkout with WeChat">
                                                             <color key="titleColor" systemColor="labelColor"/>
@@ -575,26 +575,26 @@
             <objects>
                 <viewController id="3dc-1g-4U7" customClass="OptionsViewController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8AO-7M-Nu3">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lyV-gZ-kEV">
-                                <rect key="frame" x="0.0" y="44" width="320" height="436"/>
+                                <rect key="frame" x="0.0" y="103" width="393" height="715"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iM6-7j-oWC">
-                                        <rect key="frame" x="0.0" y="0.0" width="320" height="1076"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="393" height="1134.6666666666667"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="P74-f6-EbX">
-                                                <rect key="frame" x="16" y="16" width="288" height="1044"/>
+                                                <rect key="frame" x="16" y="16" width="361" height="1102.6666666666667"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Environment" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="I3F-HC-rpy">
-                                                        <rect key="frame" x="0.0" y="0.0" width="288" height="24"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="361" height="24"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                         <color key="textColor" name="Black Text Color"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <button opaque="NO" contentMode="scaleToFill" semanticContentAttribute="forceRightToLeft" contentHorizontalAlignment="left" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Bgd-ni-rbG" customClass="OptionButton">
-                                                        <rect key="frame" x="0.0" y="40" width="288" height="29"/>
+                                                        <rect key="frame" x="0.0" y="40" width="361" height="33"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal">
                                                             <color key="titleColor" systemColor="labelColor"/>
@@ -604,13 +604,13 @@
                                                         </connections>
                                                     </button>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Checkout Mode" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="faX-vN-ISh">
-                                                        <rect key="frame" x="0.0" y="85" width="288" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="89" width="361" height="20.333333333333329"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <color key="textColor" name="Black Text Color"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <button opaque="NO" contentMode="scaleToFill" semanticContentAttribute="forceRightToLeft" contentHorizontalAlignment="left" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="me0-Vs-F6F" customClass="OptionButton">
-                                                        <rect key="frame" x="0.0" y="121.5" width="288" height="29"/>
+                                                        <rect key="frame" x="0.0" y="125.33333333333334" width="361" height="33"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal">
                                                             <color key="titleColor" systemColor="labelColor"/>
@@ -620,13 +620,13 @@
                                                         </connections>
                                                     </button>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Next trigger by" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xdW-GS-XKJ">
-                                                        <rect key="frame" x="0.0" y="166.5" width="288" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="174.33333333333331" width="361" height="20.333333333333343"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <color key="textColor" name="Black Text Color"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <button opaque="NO" contentMode="scaleToFill" semanticContentAttribute="forceRightToLeft" contentHorizontalAlignment="left" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4fM-7O-jA1" customClass="OptionButton">
-                                                        <rect key="frame" x="0.0" y="203" width="288" height="29"/>
+                                                        <rect key="frame" x="0.0" y="210.66666666666669" width="361" height="33"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal">
                                                             <color key="titleColor" systemColor="labelColor"/>
@@ -636,16 +636,16 @@
                                                         </connections>
                                                     </button>
                                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="npe-W9-Fbf">
-                                                        <rect key="frame" x="0.0" y="248" width="288" height="31"/>
+                                                        <rect key="frame" x="0.0" y="259.66666666666669" width="361" height="31"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Requires CVC" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="opR-BI-p6S">
-                                                                <rect key="frame" x="0.0" y="0.0" width="239" height="31"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="312" height="31"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <color key="textColor" name="Black Text Color"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wjD-bf-hn5">
-                                                                <rect key="frame" x="239" y="0.0" width="51" height="31"/>
+                                                                <rect key="frame" x="312" y="0.0" width="51" height="31"/>
                                                                 <connections>
                                                                     <action selector="cvcSwitchPressed:" destination="3dc-1g-4U7" eventType="valueChanged" id="UqX-cJ-9gJ"/>
                                                                 </connections>
@@ -653,33 +653,50 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vIz-fc-oU0">
-                                                        <rect key="frame" x="0.0" y="295" width="288" height="31"/>
+                                                        <rect key="frame" x="0.0" y="306.66666666666669" width="361" height="31"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Auto Capture" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NPA-iV-tat">
-                                                                <rect key="frame" x="0.0" y="0.0" width="239" height="31"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="312" height="31"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <color key="textColor" name="Black Text Color"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="b0P-VU-G4N">
-                                                                <rect key="frame" x="239" y="0.0" width="51" height="31"/>
+                                                                <rect key="frame" x="312" y="0.0" width="51" height="31"/>
                                                                 <connections>
                                                                     <action selector="autoCaptureSwitchPressed:" destination="3dc-1g-4U7" eventType="valueChanged" id="mcf-XV-hkd"/>
                                                                 </connections>
                                                             </switch>
                                                         </subviews>
                                                     </stackView>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Hch-lF-vIa">
+                                                        <rect key="frame" x="0.0" y="353.66666666666669" width="361" height="31"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Apple Pay Checkout Method" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4O4-Bs-d1x" userLabel="Apple Pay Method Only">
+                                                                <rect key="frame" x="0.0" y="0.0" width="312" height="31"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                <color key="textColor" name="Black Text Color"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="PRs-Fj-3Cs">
+                                                                <rect key="frame" x="312" y="0.0" width="51" height="31"/>
+                                                                <connections>
+                                                                    <action selector="applePayOnlySwitchPressed:" destination="3dc-1g-4U7" eventType="valueChanged" id="tlt-fX-Bb6"/>
+                                                                </connections>
+                                                            </switch>
+                                                        </subviews>
+                                                    </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="lQz-T7-LCg">
-                                                        <rect key="frame" x="0.0" y="342" width="288" height="32"/>
+                                                        <rect key="frame" x="0.0" y="400.66666666666663" width="361" height="32"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Customer ID" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pi4-md-Lm0">
-                                                                <rect key="frame" x="0.0" y="0.0" width="138" height="32"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="211" height="32"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <color key="textColor" name="Black Text Color"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="500" horizontalCompressionResistancePriority="500" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kI2-hN-PcJ">
-                                                                <rect key="frame" x="146" y="0.0" width="142" height="32"/>
+                                                                <rect key="frame" x="219" y="0.0" width="142" height="32"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                                 <state key="normal" title="Generate Customer"/>
                                                                 <connections>
@@ -689,10 +706,10 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="DsA-0z-nCg">
-                                                        <rect key="frame" x="0.0" y="390" width="288" height="34"/>
+                                                        <rect key="frame" x="0.0" y="448.66666666666663" width="361" height="34"/>
                                                         <subviews>
                                                             <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="eE7-Om-WvW">
-                                                                <rect key="frame" x="0.0" y="0.0" width="244" height="34"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="317" height="34"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                                 <connections>
@@ -700,7 +717,7 @@
                                                                 </connections>
                                                             </textField>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oPD-sh-aXs">
-                                                                <rect key="frame" x="252" y="0.0" width="36" height="34"/>
+                                                                <rect key="frame" x="325" y="0.0" width="36" height="34"/>
                                                                 <state key="normal" title="Clear"/>
                                                                 <userDefinedRuntimeAttributes>
                                                                     <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
@@ -714,13 +731,13 @@
                                                         </subviews>
                                                     </stackView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="API Key" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J14-mn-E62">
-                                                        <rect key="frame" x="0.0" y="440" width="288" height="24"/>
+                                                        <rect key="frame" x="0.0" y="498.66666666666663" width="361" height="24"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                         <color key="textColor" name="Black Text Color"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="ucc-VN-sfr">
-                                                        <rect key="frame" x="0.0" y="480" width="288" height="34"/>
+                                                        <rect key="frame" x="0.0" y="538.66666666666663" width="361" height="34"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <textInputTraits key="textInputTraits"/>
                                                         <connections>
@@ -728,13 +745,13 @@
                                                         </connections>
                                                     </textField>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Client ID" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5p4-lS-mL2">
-                                                        <rect key="frame" x="0.0" y="530" width="288" height="24"/>
+                                                        <rect key="frame" x="0.0" y="588.66666666666663" width="361" height="24"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                         <color key="textColor" name="Black Text Color"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="Qvi-cl-UUP">
-                                                        <rect key="frame" x="0.0" y="570" width="288" height="34"/>
+                                                        <rect key="frame" x="0.0" y="628.66666666666663" width="361" height="34"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <textInputTraits key="textInputTraits"/>
                                                         <connections>
@@ -742,13 +759,13 @@
                                                         </connections>
                                                     </textField>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Amount" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5BH-xo-rjD">
-                                                        <rect key="frame" x="0.0" y="620" width="288" height="24"/>
+                                                        <rect key="frame" x="0.0" y="678.66666666666663" width="361" height="24"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                         <color key="textColor" name="Black Text Color"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="Ofq-7n-F5l">
-                                                        <rect key="frame" x="0.0" y="660" width="288" height="34"/>
+                                                        <rect key="frame" x="0.0" y="718.66666666666663" width="361" height="34"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <textInputTraits key="textInputTraits" keyboardType="decimalPad"/>
                                                         <connections>
@@ -756,13 +773,13 @@
                                                         </connections>
                                                     </textField>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Currency" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ap9-GE-PVt">
-                                                        <rect key="frame" x="0.0" y="710" width="288" height="24"/>
+                                                        <rect key="frame" x="0.0" y="768.66666666666663" width="361" height="24"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                         <color key="textColor" name="Black Text Color"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="XwV-xj-OFr">
-                                                        <rect key="frame" x="0.0" y="750" width="288" height="34"/>
+                                                        <rect key="frame" x="0.0" y="808.66666666666663" width="361" height="34"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <textInputTraits key="textInputTraits" autocapitalizationType="allCharacters"/>
                                                         <connections>
@@ -770,13 +787,13 @@
                                                         </connections>
                                                     </textField>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Country Code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cTx-Ag-RWK">
-                                                        <rect key="frame" x="0.0" y="800" width="288" height="24"/>
+                                                        <rect key="frame" x="0.0" y="858.66666666666663" width="361" height="24"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                         <color key="textColor" name="Black Text Color"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="Qdt-5n-Aof">
-                                                        <rect key="frame" x="0.0" y="840" width="288" height="34"/>
+                                                        <rect key="frame" x="0.0" y="898.66666666666663" width="361" height="34"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <textInputTraits key="textInputTraits" autocapitalizationType="allCharacters"/>
                                                         <connections>
@@ -784,13 +801,13 @@
                                                         </connections>
                                                     </textField>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Return URL" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0po-GZ-hyq">
-                                                        <rect key="frame" x="0.0" y="890" width="288" height="24"/>
+                                                        <rect key="frame" x="0.0" y="948.66666666666674" width="361" height="24"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                         <color key="textColor" name="Black Text Color"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="KSE-Ui-RbN">
-                                                        <rect key="frame" x="0.0" y="930" width="288" height="34"/>
+                                                        <rect key="frame" x="0.0" y="988.66666666666674" width="361" height="34"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <textInputTraits key="textInputTraits"/>
                                                         <connections>
@@ -798,13 +815,13 @@
                                                         </connections>
                                                     </textField>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="WeChat Region:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iou-6j-t8u">
-                                                        <rect key="frame" x="0.0" y="980" width="288" height="24"/>
+                                                        <rect key="frame" x="0.0" y="1038.6666666666667" width="361" height="24"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                         <color key="textColor" name="Black Text Color"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="App Version:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JTK-Dh-PCi">
-                                                        <rect key="frame" x="0.0" y="1020" width="288" height="24"/>
+                                                        <rect key="frame" x="0.0" y="1078.6666666666667" width="361" height="24"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                         <color key="textColor" name="Black Text Color"/>
                                                         <nil key="highlightedColor"/>
@@ -850,6 +867,7 @@
                     <connections>
                         <outlet property="amountTextField" destination="Ofq-7n-F5l" id="aoW-om-maE"/>
                         <outlet property="apiKeyTextField" destination="ucc-VN-sfr" id="EXV-PE-RMH"/>
+                        <outlet property="applePayOnlySwitch" destination="PRs-Fj-3Cs" id="k7G-5d-D9Z"/>
                         <outlet property="autoCaptureSwitch" destination="b0P-VU-G4N" id="XjT-AP-OmH"/>
                         <outlet property="checkoutBtn" destination="me0-Vs-F6F" id="hrE-Z6-xpL"/>
                         <outlet property="clearCustomerIdButton" destination="oPD-sh-aXs" id="7X4-On-5Ee"/>
@@ -885,6 +903,7 @@
                         <outletCollection property="textFields" destination="XwV-xj-OFr" id="OmO-mz-pTA"/>
                         <outletCollection property="textFields" destination="Qdt-5n-Aof" id="n10-CI-1up"/>
                         <outletCollection property="textFields" destination="KSE-Ui-RbN" id="u5A-08-vrg"/>
+                        <outletCollection property="titleLabels" destination="4O4-Bs-d1x" id="3MB-Mf-Jkc"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="6DU-lc-9l6" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -897,7 +916,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="pG9-fq-6li" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="lmz-Qw-MyF">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="50"/>
+                        <rect key="frame" x="0.0" y="59" width="393" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/README.md
+++ b/README.md
@@ -199,6 +199,42 @@ You also need to provide your host view controller which we use to present addit
 }
 ```
 
+#### Make payment with apple pay provider
+
+You still need all the other steps in [Basic Integration](#basic-integration) section to set up configurations, intent and session, except the step **Present one-off payment or recurring flow** is replaced by:
+
+```objective-c
+AWXApplePayProvider *provider = [[AWXApplePayProvider alloc] initWithDelegate:"The target to handle AWXProviderDelegate protocol" session:"The one off session created with apple pay options"];
+
+// After initialization, you will need to store the provider in your view controller or class that is tied to your view's lifecycle
+self.provider = provider;
+
+// Initiate the apple pay flow
+ [provider makePayment];
+
+``` 
+
+You also need to delegate methods to handle the result
+```objective-c
+#pragma mark - AWXProviderDelegate
+
+- (void)provider:(nonnull AWXDefaultProvider *)provider didCompleteWithStatus:(AirwallexPaymentStatus)status error:(nullable NSError *)error {
+    switch (status) {
+    case AirwallexPaymentStatusSuccess:
+       // handle success
+        break;
+    case AirwallexPaymentStatusFailure:
+       // handle failure
+        break;
+    case AirwallexPaymentStatusCancel:
+       // handle payment cancelled by the user
+        break;
+    default:
+        break;
+    }
+}
+```
+
 ### Set Up WeChat Pay
 
 After completing payment, WeChat will be redirected to the merchant's app and do a callback using onResp(), then it can retrieve the payment intent status after the merchant server is notified, so please keep listening to the notification.

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ AWXApplePayProvider *provider = [[AWXApplePayProvider alloc] initWithDelegate:"T
 self.provider = provider;
 
 // Initiate the apple pay flow
- [provider makePayment];
+ [provider startPayment];
 
 ``` 
 


### PR DESCRIPTION
- Exposed `makePayment` api in `AWXApplePayProvider` to initiate apple pay flow directly.
- Refactored implementation of AWXApplePayProvider for early check and return in case of error and also to return payment cancel status if user cancels the payment in case of payment flow initiated via `makePayment`
- Added an option in the settings screen to initiate apple pay directly when turned on instead of presenting the payment method list screen.