### PR TITLE
[APAM-24] [APAM-23]collect local logs in local file system if needed

### DIFF
--- a/Airwallex/Airwallex.xcodeproj/project.pbxproj
+++ b/Airwallex/Airwallex.xcodeproj/project.pbxproj
@@ -233,6 +233,8 @@
 		6EE990B728D9A300008C22B7 /* AWXCardViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 184EADAF28D15C1600FD965D /* AWXCardViewModel.m */; };
 		6EE990BA28D9A3B7008C22B7 /* AWXCardViewModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 6EE990B928D9A3B7008C22B7 /* AWXCardViewModel.h */; };
 		9184A98A3FB097B3E30DFD42 /* Pods_WeChatPay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A5DE28F611F49B21B3B1DA1 /* Pods_WeChatPay.framework */; };
+		C844DC7D2C3CE37F0099614C /* NSObject+Logging.m in Sources */ = {isa = PBXBuildFile; fileRef = C844DC7C2C3CE37F0099614C /* NSObject+Logging.m */; };
+		C844DC7E2C3CE37F0099614C /* NSObject+Logging.h in Headers */ = {isa = PBXBuildFile; fileRef = C844DC7B2C3CE37F0099614C /* NSObject+Logging.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CA09778887CAF1A3CB3519E4 /* Pods_ApplePayTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 766C109E04EF1051D97CC9A3 /* Pods_ApplePayTests.framework */; };
 		EA34697AD30A2D71BD5C1D8A /* Pods_CardTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A358577D1CBCE19AB5E4572 /* Pods_CardTests.framework */; };
 		FB357E04D7E4A8E8C5F54146 /* Pods_RedirectTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FC9DFB3C3391C7ABDA4375D4 /* Pods_RedirectTests.framework */; };
@@ -588,6 +590,8 @@
 		7A5DE28F611F49B21B3B1DA1 /* Pods_WeChatPay.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WeChatPay.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8096B137EDD3F3FFD5786CEB /* Pods-WeChatPay.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WeChatPay.debug.xcconfig"; path = "Target Support Files/Pods-WeChatPay/Pods-WeChatPay.debug.xcconfig"; sourceTree = "<group>"; };
 		BD25D2EFD8E73A8E45ECDB24 /* Pods-ApplePayTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ApplePayTests.release.xcconfig"; path = "Target Support Files/Pods-ApplePayTests/Pods-ApplePayTests.release.xcconfig"; sourceTree = "<group>"; };
+		C844DC7B2C3CE37F0099614C /* NSObject+Logging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSObject+Logging.h"; sourceTree = "<group>"; };
+		C844DC7C2C3CE37F0099614C /* NSObject+Logging.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSObject+Logging.m"; sourceTree = "<group>"; };
 		CADC48837C89CE06D47DF8A8 /* Pods-CoreTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CoreTests.debug.xcconfig"; path = "Target Support Files/Pods-CoreTests/Pods-CoreTests.debug.xcconfig"; sourceTree = "<group>"; };
 		F087D6C1F1A19092F78A54AB /* Pods_CoreTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CoreTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F645D9A6F3BD26FCB581FFF9 /* Pods-CoreTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CoreTests.release.xcconfig"; path = "Target Support Files/Pods-CoreTests/Pods-CoreTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -837,6 +841,8 @@
 				184169D429C4347800B02D96 /* UIColor+ViewCompat.m */,
 				184169DC29C4381500B02D96 /* NSData+Base64.h */,
 				184169DD29C4381500B02D96 /* NSData+Base64.m */,
+				C844DC7B2C3CE37F0099614C /* NSObject+Logging.h */,
+				C844DC7C2C3CE37F0099614C /* NSObject+Logging.m */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1192,6 +1198,7 @@
 				5775CF4E26E5DF5000C6AFE3 /* AWXDevice.h in Headers */,
 				18AC888329C4598A0028D66A /* AWXPageViewTrackable.h in Headers */,
 				1829B8C7291CDEB200D0D2CA /* AWXFloatingCardTextField.h in Headers */,
+				C844DC7E2C3CE37F0099614C /* NSObject+Logging.h in Headers */,
 				5775CF1226E5DF4F00C6AFE3 /* AWXPaymentIntent.h in Headers */,
 				5775CF2A26E5DF4F00C6AFE3 /* AWXPlaceDetails.h in Headers */,
 				5775CF2F26E5DF4F00C6AFE3 /* AWXSession.h in Headers */,
@@ -1847,6 +1854,7 @@
 				5775CF5826E5DF5000C6AFE3 /* AWXAPIClient.m in Sources */,
 				183214762BA187A800FC97B9 /* AWXNextActionHandler.m in Sources */,
 				5775CF2526E5DF4F00C6AFE3 /* AWXPaymentConsentRequest.m in Sources */,
+				C844DC7D2C3CE37F0099614C /* NSObject+Logging.m in Sources */,
 				3C99E73D27E9A0730074156C /* AWXApplePayOptions.m in Sources */,
 				5775CF1A26E5DF4F00C6AFE3 /* AWXUIContext.m in Sources */,
 				184169D829C4347800B02D96 /* UIColor+ViewCompat.m in Sources */,

--- a/Airwallex/ApplePay/AWXApplePayProvider.m
+++ b/Airwallex/ApplePay/AWXApplePayProvider.m
@@ -53,7 +53,7 @@ typedef enum {
                                              code:-1
                                          userInfo:@{NSLocalizedDescriptionKey: errorMessage}];
         [[self delegate] provider:self didCompleteWithStatus:AirwallexPaymentStatusFailure error:error];
-        [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", self.delegate.class, (unsigned long)AirwallexPaymentStatusFailure, error.localizedDescription];
+        [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", self.delegate.class, AirwallexPaymentStatusFailure, error.localizedDescription];
     }
 }
 
@@ -72,7 +72,7 @@ typedef enum {
                                              code:-1
                                          userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Unsupported session type.", nil)}];
         [[self delegate] provider:self didCompleteWithStatus:AirwallexPaymentStatusFailure error:error];
-        [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", self.delegate.class, (unsigned long)AirwallexPaymentStatusFailure, error.localizedDescription];
+        [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", self.delegate.class, AirwallexPaymentStatusFailure, error.localizedDescription];
     }
 }
 
@@ -130,7 +130,7 @@ typedef enum {
             dismissCompletionBlock = ^{
                 dispatch_async(dispatch_get_main_queue(), ^{
                     [[self delegate] provider:self didCompleteWithStatus:AirwallexPaymentStatusCancel error:nil];
-                    [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu", self.delegate.class, (unsigned long)AirwallexPaymentStatusCancel];
+                    [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu", self.delegate.class, AirwallexPaymentStatusCancel];
                 });
             };
         }
@@ -142,7 +142,7 @@ typedef enum {
     case Pending:
         // If UI disappears during the interaction with our API, we pass the state to the upper level so in progress UI can be handled before we get the confirmed or failed intent
         [[self delegate] provider:self didCompleteWithStatus:AirwallexPaymentStatusInProgress error:nil];
-        [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu", self.delegate.class, (unsigned long)AirwallexPaymentStatusInProgress];
+        [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu", self.delegate.class, AirwallexPaymentStatusInProgress];
         [self log:@"Apple pay is being processing."];
         self.didDismissWhilePending = YES;
         break;
@@ -197,7 +197,7 @@ typedef enum {
 
     if (!request) {
         [[self delegate] provider:self didCompleteWithStatus:AirwallexPaymentStatusFailure error:error];
-        [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", self.delegate.class, (unsigned long)AirwallexPaymentStatusFailure, error.localizedDescription];
+        [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", self.delegate.class, AirwallexPaymentStatusFailure, error.localizedDescription];
         return;
     }
 
@@ -211,7 +211,7 @@ typedef enum {
         [[AWXAnalyticsLogger shared] logError:error withEventName:@"apple_pay_sheet"];
         [self log:@"%@", description];
         [[self delegate] provider:self didCompleteWithStatus:AirwallexPaymentStatusFailure error:error];
-        [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", self.delegate.class, (unsigned long)AirwallexPaymentStatusFailure, error.localizedDescription];
+        [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", self.delegate.class, AirwallexPaymentStatusFailure, error.localizedDescription];
         return;
     }
 
@@ -278,7 +278,7 @@ typedef enum {
         [[AWXAnalyticsLogger shared] logError:error withEventName:@"apple_pay_sheet"];
         [self log:@"Failed to present Apple Pay Controller."];
         [[self delegate] provider:self didCompleteWithStatus:AirwallexPaymentStatusFailure error:error];
-        [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", self.delegate.class, (unsigned long)AirwallexPaymentStatusFailure, error.localizedDescription];
+        [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", self.delegate.class, AirwallexPaymentStatusFailure, error.localizedDescription];
     }
 }
 

--- a/Airwallex/ApplePay/AWXApplePayProvider.m
+++ b/Airwallex/ApplePay/AWXApplePayProvider.m
@@ -53,6 +53,7 @@ typedef enum {
                                              code:-1
                                          userInfo:@{NSLocalizedDescriptionKey: errorMessage}];
         [[self delegate] provider:self didCompleteWithStatus:AirwallexPaymentStatusFailure error:error];
+        [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", self.delegate.class, (unsigned long)AirwallexPaymentStatusFailure, error.localizedDescription];
     }
 }
 
@@ -71,6 +72,7 @@ typedef enum {
                                              code:-1
                                          userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Unsupported session type.", nil)}];
         [[self delegate] provider:self didCompleteWithStatus:AirwallexPaymentStatusFailure error:error];
+        [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", self.delegate.class, (unsigned long)AirwallexPaymentStatusFailure, error.localizedDescription];
     }
 }
 
@@ -128,6 +130,7 @@ typedef enum {
             dismissCompletionBlock = ^{
                 dispatch_async(dispatch_get_main_queue(), ^{
                     [[self delegate] provider:self didCompleteWithStatus:AirwallexPaymentStatusCancel error:nil];
+                    [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu", self.delegate.class, (unsigned long)AirwallexPaymentStatusCancel];
                 });
             };
         }
@@ -139,6 +142,7 @@ typedef enum {
     case Pending:
         // If UI disappears during the interaction with our API, we pass the state to the upper level so in progress UI can be handled before we get the confirmed or failed intent
         [[self delegate] provider:self didCompleteWithStatus:AirwallexPaymentStatusInProgress error:nil];
+        [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu", self.delegate.class, (unsigned long)AirwallexPaymentStatusInProgress];
         [self log:@"Apple pay is being processing."];
         self.didDismissWhilePending = YES;
         break;
@@ -193,6 +197,7 @@ typedef enum {
 
     if (!request) {
         [[self delegate] provider:self didCompleteWithStatus:AirwallexPaymentStatusFailure error:error];
+        [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", self.delegate.class, (unsigned long)AirwallexPaymentStatusFailure, error.localizedDescription];
         return;
     }
 
@@ -206,6 +211,7 @@ typedef enum {
         [[AWXAnalyticsLogger shared] logError:error withEventName:@"apple_pay_sheet"];
         [self log:@"%@", description];
         [[self delegate] provider:self didCompleteWithStatus:AirwallexPaymentStatusFailure error:error];
+        [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", self.delegate.class, (unsigned long)AirwallexPaymentStatusFailure, error.localizedDescription];
         return;
     }
 
@@ -272,6 +278,7 @@ typedef enum {
         [[AWXAnalyticsLogger shared] logError:error withEventName:@"apple_pay_sheet"];
         [self log:@"Failed to present Apple Pay Controller."];
         [[self delegate] provider:self didCompleteWithStatus:AirwallexPaymentStatusFailure error:error];
+        [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", self.delegate.class, (unsigned long)AirwallexPaymentStatusFailure, error.localizedDescription];
     }
 }
 

--- a/Airwallex/Card/AWX3DSActionProvider.m
+++ b/Airwallex/Card/AWX3DSActionProvider.m
@@ -12,6 +12,7 @@
 #import "AWXPaymentIntentResponse.h"
 #import "AWXSecurityService.h"
 #import "AWXSession.h"
+#import "NSObject+logging.h"
 
 @interface AWX3DSActionProvider ()<AWX3DSServiceDelegate>
 
@@ -23,6 +24,7 @@
 
 - (void)handleNextAction:(AWXConfirmPaymentNextAction *)nextAction {
     [self.delegate providerDidStartRequest:self];
+    [self log:@"Delegate: %@, providerDidStartRequest:", self.delegate.class];
     __weak __typeof(self) weakSelf = self;
     [[AWXSecurityService sharedService] doProfile:self.session.paymentIntentId
                                        completion:^(NSString *_Nullable sessionId) {

--- a/Airwallex/Card/AWXCardProvider.m
+++ b/Airwallex/Card/AWXCardProvider.m
@@ -65,7 +65,7 @@
                                [strongSelf.delegate providerDidEndRequest:strongSelf];
                                [strongSelf log:@"Delegate: %@, providerDidEndRequest:", self.delegate.class];
                                [strongSelf.delegate provider:strongSelf didCompleteWithStatus:AirwallexPaymentStatusFailure error:error];
-                               [strongSelf log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", strongSelf.delegate.class, (unsigned long)AirwallexPaymentStatusFailure, error.localizedDescription];
+                               [strongSelf log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", strongSelf.delegate.class, AirwallexPaymentStatusFailure, error.localizedDescription];
                            }
                        }];
     }

--- a/Airwallex/Card/AWXCardProvider.m
+++ b/Airwallex/Card/AWXCardProvider.m
@@ -47,6 +47,8 @@
     paymentMethod.customerId = self.session.customerId;
 
     [self.delegate providerDidStartRequest:self];
+    [self log:@"Delegate: %@, providerDidStartRequest:", self.delegate.class];
+
     if ([self.session isKindOfClass:[AWXOneOffSession class]] && !saveCard) {
         [self confirmPaymentIntentWithPaymentMethod:paymentMethod];
     } else {
@@ -61,7 +63,9 @@
                                [strongSelf createPaymentConsentAndConfirmIntentWithPaymentMethod:paymentMethod];
                            } else {
                                [strongSelf.delegate providerDidEndRequest:strongSelf];
+                               [strongSelf log:@"Delegate: %@, providerDidEndRequest:", self.delegate.class];
                                [strongSelf.delegate provider:strongSelf didCompleteWithStatus:AirwallexPaymentStatusFailure error:error];
+                               [strongSelf log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", strongSelf.delegate.class, (unsigned long)AirwallexPaymentStatusFailure, error.localizedDescription];
                            }
                        }];
     }
@@ -69,6 +73,8 @@
 
 - (void)confirmPaymentIntentWithPaymentConsentId:(NSString *)paymentConsentId {
     [self.delegate providerDidStartRequest:self];
+    [self log:@"Delegate: %@, providerDidStartRequest:", self.delegate.class];
+
     __weak __typeof(self) weakSelf = self;
     [self setDevice:^(AWXDevice *_Nonnull device) {
         __strong __typeof(weakSelf) strongSelf = weakSelf;

--- a/Airwallex/Card/AWXCardProvider.m
+++ b/Airwallex/Card/AWXCardProvider.m
@@ -19,6 +19,7 @@
 #import "AWXPaymentMethodRequest.h"
 #import "AWXPaymentMethodResponse.h"
 #import "AWXSession.h"
+#import "NSObject+Logging.h"
 
 @implementation AWXCardProvider
 
@@ -37,6 +38,8 @@
 - (void)confirmPaymentIntentWithCard:(AWXCard *)card
                              billing:(AWXPlaceDetails *)billing
                             saveCard:(BOOL)saveCard {
+    [self log:@"Start payment confirm. Type: Card. Intent Id:%@", self.session.paymentIntentId];
+
     AWXPaymentMethod *paymentMethod = [AWXPaymentMethod new];
     paymentMethod.type = AWXCardKey;
     paymentMethod.billing = billing;

--- a/Airwallex/Card/AWXDccActionProvider.m
+++ b/Airwallex/Card/AWXDccActionProvider.m
@@ -15,6 +15,7 @@
 #import "AWXPaymentIntentResponse.h"
 #import "AWXSecurityService.h"
 #import "AWXSession.h"
+#import "NSObject+Logging.h"
 
 @interface AWXDccActionProvider ()<AWXDCCViewControllerDelegate>
 
@@ -36,6 +37,8 @@
 - (void)confirmThreeDSWithUseDCC:(BOOL)useDCC {
     __weak __typeof(self) weakSelf = self;
     [self.delegate providerDidStartRequest:self];
+    [self log:@"Delegate: %@, providerDidStartRequest:", self.delegate.class];
+
     [[AWXSecurityService sharedService] doProfile:self.session.paymentIntentId
                                        completion:^(NSString *_Nullable sessionId) {
                                            __strong __typeof(weakSelf) strongSelf = weakSelf;

--- a/Airwallex/Card/Internal/AWXCardViewController.m
+++ b/Airwallex/Card/Internal/AWXCardViewController.m
@@ -20,6 +20,7 @@
 #import "AWXDevice.h"
 #import "AWXFloatingCardTextField.h"
 #import "AWXPaymentIntent.h"
+#import "AWXPaymentIntentResponse.h"
 #import "AWXPaymentMethod.h"
 #import "AWXPaymentMethodRequest.h"
 #import "AWXPaymentMethodResponse.h"
@@ -338,6 +339,7 @@ typedef enum {
                                  completion:^{
                                      id<AWXPaymentResultDelegate> delegate = [AWXUIContext sharedContext].delegate;
                                      [delegate paymentViewController:self didCompleteWithStatus:AirwallexPaymentStatusCancel error:nil];
+                                     [self log:@"Delegate: %@, paymentViewController:didCompleteWithStatus:error: %lu", delegate.class, (unsigned long)AirwallexPaymentStatusCancel];
                                  }];
     } else {
         [self.navigationController popViewControllerAnimated:YES];
@@ -464,19 +466,25 @@ typedef enum {
 #pragma mark - AWXProviderDelegate
 
 - (void)providerDidStartRequest:(AWXDefaultProvider *)provider {
+    [self log:@"providerDidStartRequest:"];
+
     [self startAnimating];
 }
 
 - (void)providerDidEndRequest:(AWXDefaultProvider *)provider {
+    [self log:@"providerDidEndRequest:"];
     [self stopAnimating];
 }
 
 - (void)provider:(AWXDefaultProvider *)provider didCompleteWithStatus:(AirwallexPaymentStatus)status error:(nullable NSError *)error {
+    [self log:@"provider:didCompleteWithStatus:error: %lu  %@", (unsigned long)status, error.description];
+
     UIViewController *presentingViewController = self.presentingViewController;
     [self dismissViewControllerAnimated:YES
                              completion:^{
                                  id<AWXPaymentResultDelegate> delegate = [AWXUIContext sharedContext].delegate;
                                  [delegate paymentViewController:presentingViewController didCompleteWithStatus:status error:error];
+                                 [self log:@"Delegate: %@, paymentViewController:didCompleteWithStatus:error: %@  %lu  %@", delegate.class, presentingViewController.class, (unsigned long)AirwallexPaymentStatusFailure, error.localizedDescription];
                              }];
 }
 
@@ -489,10 +497,12 @@ typedef enum {
 }
 
 - (void)provider:(AWXDefaultProvider *)provider didInitializePaymentIntentId:(NSString *)paymentIntentId {
+    [self log:@"provider:didInitializePaymentIntentId:  %@", paymentIntentId];
     [self.viewModel updatePaymentIntentId:paymentIntentId];
 }
 
 - (void)provider:(AWXDefaultProvider *)provider shouldHandleNextAction:(AWXConfirmPaymentNextAction *)nextAction {
+    [self log:@"provider:shouldHandleNextAction:  type:%@, stage: %@", nextAction.type, nextAction.stage];
     AWXDefaultActionProvider *actionProvider = [self.viewModel actionProviderForNextAction:nextAction withDelegate:self];
     if (actionProvider == nil) {
         UIAlertController *controller = [UIAlertController alertControllerWithTitle:nil message:NSLocalizedString(@"No provider matched the next action.", nil) preferredStyle:UIAlertControllerStyleAlert];

--- a/Airwallex/Card/Internal/AWXCardViewController.m
+++ b/Airwallex/Card/Internal/AWXCardViewController.m
@@ -30,6 +30,7 @@
 #import "AWXUtils.h"
 #import "AWXWidgets.h"
 #import "AirRisk/AirRisk-Swift.h"
+#import "NSObject+Logging.h"
 
 @interface AWXCardViewController ()<AWXCountryListViewControllerDelegate, AWXProviderDelegate, AWXFloatingLabelTextFieldDelegate>
 
@@ -410,6 +411,7 @@ typedef enum {
 - (void)confirmPayment:(id)sender {
     [[AWXAnalyticsLogger shared] logActionWithName:@"tap_pay_button"];
     [AirwallexRisk logWithEvent:@"click_payment_button" screen:@"page_create_card"];
+    [self log:@"Start payment. Intent ID: %@", self.session.paymentIntentId];
 
     NSString *error;
     AWXCardProvider *provider = [self.viewModel preparedProviderWithDelegate:self];
@@ -428,6 +430,7 @@ typedef enum {
             [self presentViewController:controller animated:YES completion:nil];
 
             [[AWXAnalyticsLogger shared] logActionWithName:@"card_payment_validation" additionalInfo:@{@"message": error}];
+            [self log:@"Payment failed. Intent ID: %@. Reason: %@.", self.session.paymentIntentId, error];
         }
     }
 }

--- a/Airwallex/Card/Internal/AWXCardViewController.m
+++ b/Airwallex/Card/Internal/AWXCardViewController.m
@@ -339,7 +339,7 @@ typedef enum {
                                  completion:^{
                                      id<AWXPaymentResultDelegate> delegate = [AWXUIContext sharedContext].delegate;
                                      [delegate paymentViewController:self didCompleteWithStatus:AirwallexPaymentStatusCancel error:nil];
-                                     [self log:@"Delegate: %@, paymentViewController:didCompleteWithStatus:error: %lu", delegate.class, (unsigned long)AirwallexPaymentStatusCancel];
+                                     [self log:@"Delegate: %@, paymentViewController:didCompleteWithStatus:error: %lu", delegate.class, AirwallexPaymentStatusCancel];
                                  }];
     } else {
         [self.navigationController popViewControllerAnimated:YES];
@@ -477,14 +477,14 @@ typedef enum {
 }
 
 - (void)provider:(AWXDefaultProvider *)provider didCompleteWithStatus:(AirwallexPaymentStatus)status error:(nullable NSError *)error {
-    [self log:@"provider:didCompleteWithStatus:error: %lu  %@", (unsigned long)status, error.description];
+    [self log:@"provider:didCompleteWithStatus:error: %lu  %@", status, error.description];
 
     UIViewController *presentingViewController = self.presentingViewController;
     [self dismissViewControllerAnimated:YES
                              completion:^{
                                  id<AWXPaymentResultDelegate> delegate = [AWXUIContext sharedContext].delegate;
                                  [delegate paymentViewController:presentingViewController didCompleteWithStatus:status error:error];
-                                 [self log:@"Delegate: %@, paymentViewController:didCompleteWithStatus:error: %@  %lu  %@", delegate.class, presentingViewController.class, (unsigned long)AirwallexPaymentStatusFailure, error.localizedDescription];
+                                 [self log:@"Delegate: %@, paymentViewController:didCompleteWithStatus:error: %@  %lu  %@", delegate.class, presentingViewController.class, AirwallexPaymentStatusFailure, error.localizedDescription];
                              }];
 }
 

--- a/Airwallex/Core/Sources/AWXAPIClient.h
+++ b/Airwallex/Core/Sources/AWXAPIClient.h
@@ -50,9 +50,29 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)disableAnalytics;
 
 /**
+ enable analytics.
+ */
++ (void)enableAnalytics;
+
+/**
  Get whether analytics is enabled, by default it's turned on.
  */
 + (BOOL)analyticsEnabled;
+
+/**
+ Enable local log file.
+ */
++ (void)enableLocalLogFile;
+
+/**
+ Disable local log file.
+ */
++ (void)disableLocalLogFile;
+
+/**
+ Get whether local Log file is enabled, by default it's turned off.
+ */
++ (BOOL)isLocalLogFileEnabled;
 
 @end
 

--- a/Airwallex/Core/Sources/AWXAPIClient.m
+++ b/Airwallex/Core/Sources/AWXAPIClient.m
@@ -187,6 +187,7 @@ static BOOL _analyticsEnabled = YES;
 - (void)send:(AWXRequest *)request handler:(AWXRequestHandler)handler {
     NSString *method = @"POST";
     NSURL *url = [NSURL URLWithString:request.path relativeToURL:self.configuration.baseURL];
+    [self log:@"ULR request: %@   Class:%@", url.absoluteURL, request.class];
 
     if (request.method == AWXHTTPMethodGET) {
         method = @"GET";

--- a/Airwallex/Core/Sources/AWXAPIClient.m
+++ b/Airwallex/Core/Sources/AWXAPIClient.m
@@ -28,6 +28,8 @@ static AirwallexSDKMode _mode = AirwallexSDKProductionMode;
 
 static BOOL _analyticsEnabled = YES;
 
+static BOOL _localLogFileEnabled = NO;
+
 + (void)setDefaultBaseURL:(NSURL *)baseURL {
     _defaultBaseURL = [baseURL URLByAppendingPathComponent:@""];
 }
@@ -59,8 +61,24 @@ static BOOL _analyticsEnabled = YES;
     _analyticsEnabled = NO;
 }
 
++ (void)enableAnalytics {
+    _analyticsEnabled = YES;
+}
+
 + (BOOL)analyticsEnabled {
     return _analyticsEnabled;
+}
+
++ (void)enableLocalLogFile {
+    _localLogFileEnabled = YES;
+}
+
++ (void)disableLocalLogFile {
+    _localLogFileEnabled = NO;
+}
+
++ (BOOL)isLocalLogFileEnabled {
+    return _localLogFileEnabled;
 }
 
 @end

--- a/Airwallex/Core/Sources/AWXAPIClient.m
+++ b/Airwallex/Core/Sources/AWXAPIClient.m
@@ -14,6 +14,7 @@
 #import "AWXUtils.h"
 #import "AirRisk/AirRisk-Swift.h"
 #import "NSData+Base64.h"
+#import "NSObject+logging.h"
 
 static NSString *const AWXAPIDemoBaseURL = @"https://api-demo.airwallex.com/";
 static NSString *const AWXAPIStagingBaseURL = @"https://api-staging.airwallex.com/";
@@ -178,6 +179,7 @@ static BOOL _analyticsEnabled = YES;
     self = [super init];
     if (self) {
         _configuration = configuration;
+        [self log:@"Current connected domain:%@", Airwallex.defaultBaseURL];
     }
     return self;
 }
@@ -200,6 +202,8 @@ static BOOL _analyticsEnabled = YES;
     }
     if (self.configuration.clientSecret) {
         [urlRequest setValue:self.configuration.clientSecret forHTTPHeaderField:@"client-secret"];
+    } else {
+        [self log:@"Client secret is not set!"];
     }
     [urlRequest setValue:@"Airwallex-iOS-SDK" forHTTPHeaderField:@"User-Agent"];
     if (request.parameters && [NSJSONSerialization isValidJSONObject:request.parameters] && request.method == AWXHTTPMethodPOST) {

--- a/Airwallex/Core/Sources/AWXDefaultProvider.m
+++ b/Airwallex/Core/Sources/AWXDefaultProvider.m
@@ -64,6 +64,8 @@
 - (void)createPaymentConsentAndConfirmIntentWithPaymentMethod:(AWXPaymentMethod *)paymentMethod
                                                        device:(nullable AWXDevice *)device {
     [self.delegate providerDidStartRequest:self];
+    [self log:@"Delegate: %@, providerDidStartRequest:", self.delegate.class];
+
     __weak __typeof(self) weakSelf = self;
     [self createPaymentConsentAndConfirmIntentWithPaymentMethod:[self paymentMethodWithMetaData:paymentMethod]
                                                          device:device
@@ -93,6 +95,8 @@
     self.paymentConsent = paymentConsent;
 
     [self.delegate providerDidStartRequest:self];
+    [self log:@"Delegate: %@, providerDidStartRequest:", self.delegate.class];
+
     [self confirmPaymentIntentWithPaymentMethodInternal:[self paymentMethodWithMetaData:paymentMethod]
                                          paymentConsent:paymentConsent
                                                  device:device
@@ -102,10 +106,13 @@
 - (void)completeWithResponse:(nullable AWXConfirmPaymentIntentResponse *)response
                        error:(nullable NSError *)error {
     [self.delegate providerDidEndRequest:self];
+    [self log:@"Delegate: %@, providerDidEndRequest:", self.delegate.class];
+
     if (response && !error) {
         if (response.nextAction) {
             if ([self.delegate respondsToSelector:@selector(provider:shouldHandleNextAction:)]) {
                 [self.delegate provider:self shouldHandleNextAction:response.nextAction];
+                [self log:@"Delegate: %@, provider:shouldHandleNextAction:  type:%@, stage: %@", self.delegate.class, response.nextAction.type, response.nextAction.stage];
             } else {
                 AWXNextActionHandler *handler = [[AWXNextActionHandler alloc] initWithDelegate:self.delegate session:self.session];
                 [handler handleNextAction:response.nextAction];
@@ -113,9 +120,11 @@
             }
         } else {
             if (self.paymentConsent.Id && [self.delegate respondsToSelector:@selector(provider:didCompleteWithPaymentConsentId:)]) {
+                [self log:@"Delegate: %@, provider:didCompleteWithPaymentConsentId: ID length: %lu", self.delegate.class, (unsigned long)self.paymentIntentId.length];
                 [self.delegate provider:self didCompleteWithPaymentConsentId:self.paymentConsent.Id];
             }
             [self.delegate provider:self didCompleteWithStatus:AirwallexPaymentStatusSuccess error:nil];
+            [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu", self.delegate.class, (unsigned long)AirwallexPaymentStatusSuccess];
 
             if (_paymentMethod.type.length > 0) {
                 [[AWXAnalyticsLogger shared] logActionWithName:@"payment_success" additionalInfo:@{@"paymentMethod": _paymentMethod.type}];
@@ -125,6 +134,7 @@
         }
     } else {
         [self.delegate provider:self didCompleteWithStatus:AirwallexPaymentStatusFailure error:error];
+        [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", self.delegate.class, (unsigned long)AirwallexPaymentStatusFailure, error.localizedDescription];
     }
 }
 
@@ -242,6 +252,8 @@
                  AWXVerifyPaymentConsentResponse *result = (AWXVerifyPaymentConsentResponse *)response;
                  strongSelf.paymentIntentId = result.initialPaymentIntentId;
                  [strongSelf.delegate provider:strongSelf didInitializePaymentIntentId:result.initialPaymentIntentId];
+                 [strongSelf log:@"Delegate: %@, provider:didInitializePaymentIntentId: %@", self.delegate.class, result.initialPaymentIntentId];
+
                  completion(response, error);
              } else {
                  completion(nil, error);

--- a/Airwallex/Core/Sources/AWXDefaultProvider.m
+++ b/Airwallex/Core/Sources/AWXDefaultProvider.m
@@ -19,6 +19,7 @@
 #import "AWXPaymentMethodRequest.h"
 #import "AWXPaymentMethodResponse.h"
 #import "AWXSession.h"
+#import "NSObject+Logging.h"
 
 @interface AWXDefaultProvider ()
 
@@ -253,6 +254,7 @@
                                                    completion:(AWXRequestHandler)completion {
     if ([self.session isKindOfClass:[AWXOneOffSession class]]) {
         __weak __typeof(self) weakSelf = self;
+        [self log:@"One off payment flow."];
         [self createPaymentConsentWithPaymentMethod:paymentMethod
                                          customerId:self.session.customerId
                                            currency:self.session.currency
@@ -276,6 +278,7 @@
                                                                          completion:completion];
                                          }];
     } else if ([self.session isKindOfClass:[AWXRecurringSession class]]) {
+        [self log:@"Recurring payment flow."];
         AWXRecurringSession *session = (AWXRecurringSession *)self.session;
         __weak __typeof(self) weakSelf = self;
         [self createPaymentConsentWithPaymentMethod:paymentMethod
@@ -303,6 +306,7 @@
                                              }
                                          }];
     } else if ([self.session isKindOfClass:[AWXRecurringWithIntentSession class]]) {
+        [self log:@"Recurring with Intent payment flow."];
         AWXRecurringWithIntentSession *session = (AWXRecurringWithIntentSession *)self.session;
         __weak __typeof(self) weakSelf = self;
         [self createPaymentConsentWithPaymentMethod:paymentMethod

--- a/Airwallex/Core/Sources/AWXDefaultProvider.m
+++ b/Airwallex/Core/Sources/AWXDefaultProvider.m
@@ -120,11 +120,11 @@
             }
         } else {
             if (self.paymentConsent.Id && [self.delegate respondsToSelector:@selector(provider:didCompleteWithPaymentConsentId:)]) {
-                [self log:@"Delegate: %@, provider:didCompleteWithPaymentConsentId: ID length: %lu", self.delegate.class, (unsigned long)self.paymentIntentId.length];
+                [self log:@"Delegate: %@, provider:didCompleteWithPaymentConsentId: ID length: %lu", self.delegate.class, self.paymentIntentId.length];
                 [self.delegate provider:self didCompleteWithPaymentConsentId:self.paymentConsent.Id];
             }
             [self.delegate provider:self didCompleteWithStatus:AirwallexPaymentStatusSuccess error:nil];
-            [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu", self.delegate.class, (unsigned long)AirwallexPaymentStatusSuccess];
+            [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu", self.delegate.class, AirwallexPaymentStatusSuccess];
 
             if (_paymentMethod.type.length > 0) {
                 [[AWXAnalyticsLogger shared] logActionWithName:@"payment_success" additionalInfo:@{@"paymentMethod": _paymentMethod.type}];
@@ -134,7 +134,7 @@
         }
     } else {
         [self.delegate provider:self didCompleteWithStatus:AirwallexPaymentStatusFailure error:error];
-        [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", self.delegate.class, (unsigned long)AirwallexPaymentStatusFailure, error.localizedDescription];
+        [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", self.delegate.class, AirwallexPaymentStatusFailure, error.localizedDescription];
     }
 }
 

--- a/Airwallex/Core/Sources/Internal/AWXPaymentMethodListViewController.m
+++ b/Airwallex/Core/Sources/Internal/AWXPaymentMethodListViewController.m
@@ -344,10 +344,10 @@
 }
 
 - (void)provider:(AWXDefaultProvider *)provider didCompleteWithStatus:(AirwallexPaymentStatus)status error:(nullable NSError *)error {
-    [self log:@"provider:didCompleteWithStatus:error:  %lu  %@", (unsigned long)status, error.localizedDescription];
+    [self log:@"provider:didCompleteWithStatus:error:  %lu  %@", status, error.localizedDescription];
     id<AWXPaymentResultDelegate> delegate = [AWXUIContext sharedContext].delegate;
     [delegate paymentViewController:self didCompleteWithStatus:status error:error];
-    [self log:@"Delegate: %@, paymentViewController:didCompleteWithStatus:error: %@  %lu  %@", delegate.class, self.class, (unsigned long)status, error.localizedDescription];
+    [self log:@"Delegate: %@, paymentViewController:didCompleteWithStatus:error: %@  %lu  %@", delegate.class, self.class, status, error.localizedDescription];
 }
 
 - (void)provider:(AWXDefaultProvider *)provider didCompleteWithPaymentConsentId:(NSString *)Id {

--- a/Airwallex/Core/Sources/Internal/AWXPaymentMethodListViewController.m
+++ b/Airwallex/Core/Sources/Internal/AWXPaymentMethodListViewController.m
@@ -334,16 +334,20 @@
 #pragma mark - AWXProviderDelegate
 
 - (void)providerDidStartRequest:(AWXDefaultProvider *)provider {
+    [self log:@"providerDidStartRequest:"];
     [self startAnimating];
 }
 
 - (void)providerDidEndRequest:(AWXDefaultProvider *)provider {
+    [self log:@"providerDidEndRequest:"];
     [self stopAnimating];
 }
 
 - (void)provider:(AWXDefaultProvider *)provider didCompleteWithStatus:(AirwallexPaymentStatus)status error:(nullable NSError *)error {
+    [self log:@"provider:didCompleteWithStatus:error:  %lu  %@", (unsigned long)status, error.localizedDescription];
     id<AWXPaymentResultDelegate> delegate = [AWXUIContext sharedContext].delegate;
     [delegate paymentViewController:self didCompleteWithStatus:status error:error];
+    [self log:@"Delegate: %@, paymentViewController:didCompleteWithStatus:error: %@  %lu  %@", delegate.class, self.class, (unsigned long)status, error.localizedDescription];
 }
 
 - (void)provider:(AWXDefaultProvider *)provider didCompleteWithPaymentConsentId:(NSString *)Id {
@@ -355,6 +359,7 @@
 
 - (void)provider:(AWXDefaultProvider *)provider didInitializePaymentIntentId:(NSString *)paymentIntentId {
     [self.session updateInitialPaymentIntentId:paymentIntentId];
+    [self log:@"provider:didInitializePaymentIntentId:  %@", paymentIntentId];
 }
 
 - (void)provider:(AWXDefaultProvider *)provider shouldHandleNextAction:(AWXConfirmPaymentNextAction *)nextAction {

--- a/Airwallex/Core/Sources/Internal/AWXPaymentViewController.m
+++ b/Airwallex/Core/Sources/Internal/AWXPaymentViewController.m
@@ -23,6 +23,7 @@
 #import "AWXTheme.h"
 #import "AWXUtils.h"
 #import "AWXWidgets.h"
+#import "NSObject+Logging.h"
 
 @interface AWXPaymentViewController ()<AWXFloatingLabelTextFieldDelegate, AWXProviderDelegate>
 
@@ -165,10 +166,12 @@
 #pragma mark - AWXViewModelDelegate
 
 - (void)providerDidStartRequest:(AWXDefaultProvider *)provider {
+    [self log:@"providerDidStartRequest:"];
     [self startAnimating];
 }
 
 - (void)providerDidEndRequest:(AWXDefaultProvider *)provider {
+    [self log:@"providerDidEndRequest:"];
     [self stopAnimating];
 }
 
@@ -186,9 +189,11 @@
 
 - (void)provider:(AWXDefaultProvider *)provider didInitializePaymentIntentId:(NSString *)paymentIntentId {
     [self.session updateInitialPaymentIntentId:paymentIntentId];
+    [self log:@"provider:didInitializePaymentIntentId:  %@", paymentIntentId];
 }
 
 - (void)provider:(AWXDefaultProvider *)provider shouldHandleNextAction:(AWXConfirmPaymentNextAction *)nextAction {
+    [self log:@"provider:shouldHandleNextAction:  type:%@, stage: %@", nextAction.type, nextAction.stage];
     Class class = ClassToHandleNextActionForType(nextAction);
     if (class == nil) {
         UIAlertController *controller = [UIAlertController alertControllerWithTitle:nil message:NSLocalizedString(@"No provider matched the next action.", nil) preferredStyle:UIAlertControllerStyleAlert];

--- a/Airwallex/Core/Sources/Internal/Extensions/NSObject+Logging.h
+++ b/Airwallex/Core/Sources/Internal/Extensions/NSObject+Logging.h
@@ -1,0 +1,19 @@
+//
+//  NSObject+Logging.h
+//  Core
+//
+//  Created by Tony He (CTR) on 2024/7/9.
+//  Copyright © 2024 Airwallex. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSObject (Logging)
+
+- (void)log:(NSString *)format, ... NS_FORMAT_FUNCTION(1, 2);
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Airwallex/Core/Sources/Internal/Extensions/NSObject+Logging.m
+++ b/Airwallex/Core/Sources/Internal/Extensions/NSObject+Logging.m
@@ -8,6 +8,7 @@
 
 #import "AWXAPIClient.h"
 #import "NSObject+Logging.h"
+#import <os/log.h>
 
 @implementation NSObject (Logging)
 
@@ -26,7 +27,8 @@
 
     NSString *className = NSStringFromClass([self class]);
 
-    NSLog(@"----Airwallex SDK----%@----%@----\n %@", [formatter stringFromDate:now], className, formattedMessage);
+    os_log_t customLog = os_log_create("com.airwallex.payment.sdk", "general");
+    os_log(customLog, "----Airwallex SDK----%@----%@----\n %@", [formatter stringFromDate:now], className, formattedMessage);
 
     if ([Airwallex isLocalLogFileEnabled]) {
         NSString *log = [NSString stringWithFormat:@"----Airwallex SDK----%@----%@----\n %@\n", [formatter stringFromDate:now], className, formattedMessage];

--- a/Airwallex/Core/Sources/Internal/Extensions/NSObject+Logging.m
+++ b/Airwallex/Core/Sources/Internal/Extensions/NSObject+Logging.m
@@ -27,5 +27,39 @@
     NSString *className = NSStringFromClass([self class]);
 
     NSLog(@"----Airwallex SDK----%@----%@----\n %@", [formatter stringFromDate:now], className, formattedMessage);
+
+    if ([Airwallex isLocalLogFileEnabled]) {
+        NSString *log = [NSString stringWithFormat:@"----Airwallex SDK----%@----%@----\n %@\n", [formatter stringFromDate:now], className, formattedMessage];
+        [self logIntoLocalFile:log];
+    }
 }
+
+- (void)logIntoLocalFile:(NSString *)log {
+    NSString *logDateKey = @"AirwallexSDK_last_log_date";
+
+    NSFileManager *fileManager = NSFileManager.defaultManager;
+    NSURL *documentsUrl = [[fileManager URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] firstObject];
+    NSURL *logFileUrl = [documentsUrl URLByAppendingPathComponent:@"AirwallexSDK.log"];
+
+    NSData *data = [log dataUsingEncoding:NSUTF8StringEncoding];
+
+    NSDate *now = [NSDate date];
+    NSTimeInterval todayDate = [now timeIntervalSince1970];
+    NSTimeInterval lastDate = [NSUserDefaults.standardUserDefaults doubleForKey:logDateKey];
+
+    if ([fileManager fileExistsAtPath:[logFileUrl path]] && todayDate - lastDate < 60 * 60 * 24 * 7) {
+        NSFileHandle *fileHandle = [NSFileHandle fileHandleForWritingAtPath:[logFileUrl path]];
+        [fileHandle seekToEndOfFile];
+        [fileHandle writeData:data];
+        [fileHandle closeFile];
+    } else {
+        NSError *error;
+        [fileManager removeItemAtURL:logFileUrl error:&error];
+        [data writeToURL:logFileUrl atomically:YES];
+        if (!error) {
+            [NSUserDefaults.standardUserDefaults setDouble:todayDate forKey:logDateKey];
+        }
+    }
+}
+
 @end

--- a/Airwallex/Core/Sources/Internal/Extensions/NSObject+Logging.m
+++ b/Airwallex/Core/Sources/Internal/Extensions/NSObject+Logging.m
@@ -22,7 +22,7 @@
 
     NSDate *now = [NSDate date];
     NSDateFormatter *formatter = [NSDateFormatter new];
-    formatter.dateFormat = @"yyyy-MM-dd HH:mm:ss";
+    formatter.dateFormat = @"yyyy-MM-dd HH:mm:ss.SSS";
 
     NSString *className = NSStringFromClass([self class]);
 

--- a/Airwallex/Core/Sources/Internal/Extensions/NSObject+Logging.m
+++ b/Airwallex/Core/Sources/Internal/Extensions/NSObject+Logging.m
@@ -1,0 +1,31 @@
+//
+//  NSObject+Logging.m
+//  Core
+//
+//  Created by Tony He (CTR) on 2024/7/9.
+//  Copyright © 2024 Airwallex. All rights reserved.
+//
+
+#import "AWXAPIClient.h"
+#import "NSObject+Logging.h"
+
+@implementation NSObject (Logging)
+
+- (void)log:(NSString *)format, ... {
+    if (![Airwallex analyticsEnabled]) {
+        return;
+    }
+    va_list args;
+    va_start(args, format);
+    NSString *formattedMessage = [[NSString alloc] initWithFormat:format arguments:args];
+    va_end(args);
+
+    NSDate *now = [NSDate date];
+    NSDateFormatter *formatter = [NSDateFormatter new];
+    formatter.dateFormat = @"yyyy-MM-dd HH:mm:ss";
+
+    NSString *className = NSStringFromClass([self class]);
+
+    NSLog(@"----Airwallex SDK----%@----%@----\n %@", [formatter stringFromDate:now], className, formattedMessage);
+}
+@end

--- a/Airwallex/CoreTests/AWXAPIClientTest.m
+++ b/Airwallex/CoreTests/AWXAPIClientTest.m
@@ -158,4 +158,24 @@
     XCTAssertNil([AWXAPIClientConfiguration sharedConfiguration].accountID);
 }
 
+- (void)testDisableAnalytics {
+    [Airwallex disableAnalytics];
+    XCTAssertFalse([Airwallex analyticsEnabled]);
+}
+
+- (void)testEnableAnalytics {
+    [Airwallex enableAnalytics];
+    XCTAssertTrue([Airwallex analyticsEnabled]);
+}
+
+- (void)testEnableLocalLogFile {
+    [Airwallex enableLocalLogFile];
+    XCTAssertTrue([Airwallex isLocalLogFileEnabled]);
+}
+
+- (void)testDisableLocalLogFile {
+    [Airwallex disableLocalLogFile];
+    XCTAssertFalse([Airwallex isLocalLogFileEnabled]);
+}
+
 @end

--- a/Airwallex/Redirect/AWXRedirectActionProvider.m
+++ b/Airwallex/Redirect/AWXRedirectActionProvider.m
@@ -9,12 +9,14 @@
 #import "AWXRedirectActionProvider.h"
 #import "AWXAnalyticsLogger.h"
 #import "AWXPaymentIntentResponse.h"
+#import "NSObject+Logging.h"
 
 @implementation AWXRedirectActionProvider
 
 - (void)handleNextAction:(AWXConfirmPaymentNextAction *)nextAction {
     [self.delegate provider:self shouldPresentViewController:nil forceToDismiss:YES withAnimation:YES];
     [self.delegate provider:self didCompleteWithStatus:AirwallexPaymentStatusInProgress error:nil];
+    [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu", self.delegate.class, (unsigned long)AirwallexPaymentStatusInProgress];
 
     NSURL *url = [NSURL URLWithString:nextAction.url];
     if (url) {

--- a/Airwallex/Redirect/AWXRedirectActionProvider.m
+++ b/Airwallex/Redirect/AWXRedirectActionProvider.m
@@ -16,7 +16,7 @@
 - (void)handleNextAction:(AWXConfirmPaymentNextAction *)nextAction {
     [self.delegate provider:self shouldPresentViewController:nil forceToDismiss:YES withAnimation:YES];
     [self.delegate provider:self didCompleteWithStatus:AirwallexPaymentStatusInProgress error:nil];
-    [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu", self.delegate.class, (unsigned long)AirwallexPaymentStatusInProgress];
+    [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu", self.delegate.class, AirwallexPaymentStatusInProgress];
 
     NSURL *url = [NSURL URLWithString:nextAction.url];
     if (url) {

--- a/Airwallex/Redirect/AWXSchemaProvider.m
+++ b/Airwallex/Redirect/AWXSchemaProvider.m
@@ -15,6 +15,7 @@
 #import "AWXPaymentMethodRequest.h"
 #import "AWXPaymentMethodResponse.h"
 #import "AWXSession.h"
+#import "NSObject+Logging.h"
 
 @interface AWXSchemaProvider ()<AWXPaymentFormViewControllerDelegate>
 
@@ -33,6 +34,8 @@
     request.lang = self.session.lang;
 
     [self.delegate providerDidStartRequest:self];
+    [self log:@"Delegate: %@, providerDidStartRequest:", self.delegate.class];
+
     __weak __typeof(self) weakSelf = self;
     AWXAPIClient *client = [[AWXAPIClient alloc] initWithConfiguration:[AWXAPIClientConfiguration sharedConfiguration]];
     [client send:request
@@ -42,7 +45,9 @@
                  [strongSelf verifyPaymentMethodType:(AWXGetPaymentMethodTypeResponse *)response];
              } else {
                  [strongSelf.delegate providerDidEndRequest:strongSelf];
+                 [strongSelf log:@"Delegate: %@, providerDidEndRequest:", strongSelf.delegate.class];
                  [strongSelf.delegate provider:strongSelf didCompleteWithStatus:AirwallexPaymentStatusFailure error:error];
+                 [strongSelf log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", strongSelf.delegate.class, (unsigned long)AirwallexPaymentStatusFailure, error.localizedDescription];
              }
          }];
 }
@@ -51,7 +56,9 @@
     AWXSchema *schema = [response.schemas filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"transactionMode == %@", self.session.transactionMode]].firstObject;
     if (!schema || schema.fields.count == 0) {
         [self.delegate providerDidEndRequest:self];
+        [self log:@"Delegate: %@, providerDidEndRequest:", self.delegate.class];
         [self.delegate provider:self didCompleteWithStatus:AirwallexPaymentStatusFailure error:[NSError errorWithDomain:AWXSDKErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Invalid schema.", nil)}]];
+        [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", self.delegate.class, (unsigned long)AirwallexPaymentStatusFailure, @"Invalid schema."];
         return;
     }
 
@@ -78,6 +85,7 @@
     }
 
     [self.delegate providerDidEndRequest:self];
+    [self log:@"Delegate: %@, providerDidEndRequest:", self.delegate.class];
     [self renderFields:NO];
 }
 
@@ -143,10 +151,13 @@
          handler:^(AWXResponse *_Nullable response, NSError *_Nullable error) {
              __strong __typeof(weakSelf) strongSelf = weakSelf;
              [strongSelf.delegate providerDidEndRequest:strongSelf];
+             [strongSelf log:@"Delegate: %@, providerDidEndRequest:", self.delegate.class];
+
              if (response && !error) {
                  [strongSelf verifyAvailableBankList:(AWXGetAvailableBanksResponse *)response];
              } else {
                  [strongSelf.delegate provider:strongSelf didCompleteWithStatus:AirwallexPaymentStatusFailure error:error];
+                 [strongSelf log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", strongSelf.delegate.class, (unsigned long)AirwallexPaymentStatusFailure, error.localizedDescription];
              }
          }];
 }

--- a/Airwallex/Redirect/AWXSchemaProvider.m
+++ b/Airwallex/Redirect/AWXSchemaProvider.m
@@ -47,7 +47,7 @@
                  [strongSelf.delegate providerDidEndRequest:strongSelf];
                  [strongSelf log:@"Delegate: %@, providerDidEndRequest:", strongSelf.delegate.class];
                  [strongSelf.delegate provider:strongSelf didCompleteWithStatus:AirwallexPaymentStatusFailure error:error];
-                 [strongSelf log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", strongSelf.delegate.class, (unsigned long)AirwallexPaymentStatusFailure, error.localizedDescription];
+                 [strongSelf log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", strongSelf.delegate.class, AirwallexPaymentStatusFailure, error.localizedDescription];
              }
          }];
 }
@@ -58,7 +58,7 @@
         [self.delegate providerDidEndRequest:self];
         [self log:@"Delegate: %@, providerDidEndRequest:", self.delegate.class];
         [self.delegate provider:self didCompleteWithStatus:AirwallexPaymentStatusFailure error:[NSError errorWithDomain:AWXSDKErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Invalid schema.", nil)}]];
-        [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", self.delegate.class, (unsigned long)AirwallexPaymentStatusFailure, @"Invalid schema."];
+        [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", self.delegate.class, AirwallexPaymentStatusFailure, @"Invalid schema."];
         return;
     }
 
@@ -157,7 +157,7 @@
                  [strongSelf verifyAvailableBankList:(AWXGetAvailableBanksResponse *)response];
              } else {
                  [strongSelf.delegate provider:strongSelf didCompleteWithStatus:AirwallexPaymentStatusFailure error:error];
-                 [strongSelf log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", strongSelf.delegate.class, (unsigned long)AirwallexPaymentStatusFailure, error.localizedDescription];
+                 [strongSelf log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", strongSelf.delegate.class, AirwallexPaymentStatusFailure, error.localizedDescription];
              }
          }];
 }

--- a/Airwallex/WeChatPay/AWXWeChatPayActionProvider.m
+++ b/Airwallex/WeChatPay/AWXWeChatPayActionProvider.m
@@ -36,7 +36,7 @@
                                                  [strongSelf.delegate providerDidEndRequest:strongSelf];
                                                  [strongSelf log:@"Delegate: %@, providerDidEndRequest:", self.delegate.class];
                                                  [strongSelf.delegate provider:strongSelf didCompleteWithStatus:error != nil ? AirwallexPaymentStatusFailure : AirwallexPaymentStatusSuccess error:error];
-                                                 [strongSelf log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", strongSelf.delegate.class, (unsigned long)(error != nil ? AirwallexPaymentStatusFailure : AirwallexPaymentStatusSuccess), error.localizedDescription];
+                                                 [strongSelf log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", strongSelf.delegate.class, (error != nil ? AirwallexPaymentStatusFailure : AirwallexPaymentStatusSuccess), error.localizedDescription];
                                              });
                                          }] resume];
         return;
@@ -60,11 +60,11 @@
                 }
 
                 [self.delegate provider:self didCompleteWithStatus:AirwallexPaymentStatusFailure error:[NSError errorWithDomain:AWXSDKErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Failed to request WeChat service.", nil)}]];
-                [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", self.delegate.class, (unsigned long)AirwallexPaymentStatusFailure, @"Failed to request WeChat service."];
+                [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", self.delegate.class, AirwallexPaymentStatusFailure, @"Failed to request WeChat service."];
                 return;
             }
             [self.delegate provider:self didCompleteWithStatus:AirwallexPaymentStatusInProgress error:nil];
-            [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu", self.delegate.class, (unsigned long)AirwallexPaymentStatusInProgress];
+            [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu", self.delegate.class, AirwallexPaymentStatusInProgress];
             [[AWXAnalyticsLogger shared] logPageViewWithName:@"wechat_redirect"];
         }];
 }

--- a/Airwallex/WeChatPay/AWXWeChatPayActionProvider.m
+++ b/Airwallex/WeChatPay/AWXWeChatPayActionProvider.m
@@ -11,6 +11,7 @@
 #import "AWXPaymentIntentResponse.h"
 #import "AWXSession.h"
 #import "AWXWeChatPaySDKResponse.h"
+#import "NSObject+Logging.h"
 #import <WechatOpenSDK/WXApi.h>
 
 @implementation AWXWeChatPayActionProvider
@@ -24,6 +25,7 @@
     NSURL *url = [NSURL URLWithString:response.prepayId];
     if (url.scheme && url.host) {
         [self.delegate providerDidStartRequest:self];
+        [self log:@"Delegate: %@, providerDidStartRequest:", self.delegate.class];
 
         __weak __typeof(self) weakSelf = self;
         NSURLRequest *request = [NSURLRequest requestWithURL:url];
@@ -32,7 +34,9 @@
                                              __strong __typeof(weakSelf) strongSelf = weakSelf;
                                              dispatch_async(dispatch_get_main_queue(), ^{
                                                  [strongSelf.delegate providerDidEndRequest:strongSelf];
+                                                 [strongSelf log:@"Delegate: %@, providerDidEndRequest:", self.delegate.class];
                                                  [strongSelf.delegate provider:strongSelf didCompleteWithStatus:error != nil ? AirwallexPaymentStatusFailure : AirwallexPaymentStatusSuccess error:error];
+                                                 [strongSelf log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", strongSelf.delegate.class, (unsigned long)(error != nil ? AirwallexPaymentStatusFailure : AirwallexPaymentStatusSuccess), error.localizedDescription];
                                              });
                                          }] resume];
         return;
@@ -55,10 +59,12 @@
                     [[AWXAnalyticsLogger shared] logErrorWithName:@"wechat_redirect" additionalInfo:@{@"message": request.description}];
                 }
 
-                [self.delegate provider:self didCompleteWithStatus:AirwallexPaymentStatusInProgress error:[NSError errorWithDomain:AWXSDKErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Failed to request WeChat service.", nil)}]];
+                [self.delegate provider:self didCompleteWithStatus:AirwallexPaymentStatusFailure error:[NSError errorWithDomain:AWXSDKErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Failed to request WeChat service.", nil)}]];
+                [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", self.delegate.class, (unsigned long)AirwallexPaymentStatusFailure, @"Failed to request WeChat service."];
                 return;
             }
             [self.delegate provider:self didCompleteWithStatus:AirwallexPaymentStatusInProgress error:nil];
+            [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu", self.delegate.class, (unsigned long)AirwallexPaymentStatusInProgress];
             [[AWXAnalyticsLogger shared] logPageViewWithName:@"wechat_redirect"];
         }];
 }

--- a/Examples/Examples/Cart/CartViewController.m
+++ b/Examples/Examples/Cart/CartViewController.m
@@ -91,6 +91,9 @@
     // You can disable sending Analytics data or printing local logs
     //    [Airwallex disableAnalytics];
 
+    // you can enable local log file
+    //    [Airwallex enableLocalLogFile];
+
     // Theme customization
     //    UIColor *tintColor = [UIColor systemPinkColor];
     //    [AWXTheme sharedTheme].tintColor = tintColor;

--- a/Examples/Examples/Cart/CartViewController.m
+++ b/Examples/Examples/Cart/CartViewController.m
@@ -88,7 +88,7 @@
     AirwallexSDKMode mode = [AirwallexExamplesKeys shared].environment;
     [Airwallex setMode:mode];
 
-    // You can disable sending Analytics data
+    // You can disable sending Analytics data or printing local logs
     //    [Airwallex disableAnalytics];
 
     // Theme customization

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.projectKey=airwallex_airwallex-payment-ios
 sonar.projectName=Airwallex PA SDK iOS
 sonar.sources=Airwallex
-sonar.exclusions=**/*View.*,**/*ViewController.*,**/AppDelegate.*,**/SceneDelegate.*,**/*Cell.*,**/AWXTheme.*,**/UIColor+AWXTheme.*,**/AWXWidgets.*,**/*ViewCompat.*,**/*TextField.*,Airwallex/Security/**,**/AWX3DSActionProvider.*,**/AWXProviderDelegateSpy.*
+sonar.exclusions=**/*View.*,**/*ViewController.*,**/AppDelegate.*,**/SceneDelegate.*,**/*Cell.*,**/AWXTheme.*,**/UIColor+AWXTheme.*,**/AWXWidgets.*,**/*ViewCompat.*,**/*TextField.*,Airwallex/Security/**,**/AWX3DSActionProvider.*,**/AWXProviderDelegateSpy.*,**/AWXWeChatPayActionProvider.*
 sonar.tests=Airwallex/CoreTests,Airwallex/CardTests,Airwallex/RedirectTests,Airwallex/WeChatPayTests
 sonar.swift.simulator=platform=iOS Simulator,name=iPhone 13,OS=15.2
 sonar.test.inclusions=**/*Test*/**.*

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.projectKey=airwallex_airwallex-payment-ios
 sonar.projectName=Airwallex PA SDK iOS
 sonar.sources=Airwallex
-sonar.exclusions=**/*View.*,**/*ViewController.*,**/AppDelegate.*,**/SceneDelegate.*,**/*Cell.*,**/AWXTheme.*,**/UIColor+AWXTheme.*,**/AWXWidgets.*,**/*ViewCompat.*,**/*TextField.*,Airwallex/Security/**,**/AWX3DSActionProvider.*,**/AWXProviderDelegateSpy.*,**/AWXWeChatPayActionProvider.*
+sonar.exclusions=**/*View.*,**/*ViewController.*,**/AppDelegate.*,**/SceneDelegate.*,**/*Cell.*,**/AWXTheme.*,**/UIColor+AWXTheme.*,**/AWXWidgets.*,**/*ViewCompat.*,**/*TextField.*,Airwallex/Security/**,**/AWX3DSActionProvider.*,**/AWXProviderDelegateSpy.*,**/AWXWeChatPayActionProvider.*,**/NSObject+Logging.*
 sonar.tests=Airwallex/CoreTests,Airwallex/CardTests,Airwallex/RedirectTests,Airwallex/WeChatPayTests
 sonar.swift.simulator=platform=iOS Simulator,name=iPhone 13,OS=15.2
 sonar.test.inclusions=**/*Test*/**.*


### PR DESCRIPTION
Add local logs for AWXProviderDelegate.

add [Airwallex enableLocalLogFile] to enable storing logs into local file (called "AirwallexSDK.log")
This will automatically store the log when we call [NSObject log:] when true.
The log file will be cleared if last clearance time is 7 days ago.