### PR TITLE
[APAM-41] Fix open application error not returned

### DIFF
--- a/Airwallex/RedirectTests/AWXRedirectActionProviderTests.m
+++ b/Airwallex/RedirectTests/AWXRedirectActionProviderTests.m
@@ -52,7 +52,8 @@
     AWXConfirmPaymentNextAction *nextAction = [AWXConfirmPaymentNextAction decodeFromJSON:[self testDictionary]];
 
     [provider handleNextAction:nextAction];
-    OCMVerify(times(1), [_logger logErrorWithName:@"payment_redirect" additionalInfo:[self testDictionary]]);
+    NSDictionary *dict = @{NSLocalizedDescriptionKey: NSLocalizedString(@"Redirect to app failed.", nil), NSURLErrorKey: @"http://abc.net"};
+    OCMVerify(times(1), [_logger logErrorWithName:@"payment_redirect" additionalInfo:dict]);
 }
 
 - (NSDictionary *)testDictionary {


### PR DESCRIPTION
This pr fixes the issue that app redirection error is not handled:
- Return In progress status when open application succeeds
- Return fail status with error info when fails