### PR TITLE
[APAM-46] Risk improve

### DIFF
--- a/Airwallex/ApplePay/AWXApplePayProvider.m
+++ b/Airwallex/ApplePay/AWXApplePayProvider.m
@@ -15,6 +15,7 @@
 #import "AWXPaymentIntentRequest.h"
 #import "AWXPaymentIntentResponse.h"
 #import "AWXPaymentMethod.h"
+#import "AWXSecurityService.h"
 #import "AWXSession.h"
 #import "NSObject+logging.h"
 #import "PKContact+Request.h"
@@ -41,6 +42,16 @@ typedef enum {
 @end
 
 @implementation AWXApplePayProvider
+
+- (instancetype)initWithDelegate:(id<AWXProviderDelegate>)delegate session:(AWXSession *)session {
+    return [self initWithDelegate:delegate session:session paymentMethodType:nil];
+}
+
+- (instancetype)initWithDelegate:(id<AWXProviderDelegate>)delegate session:(AWXSession *)session paymentMethodType:(AWXPaymentMethodType *)paymentMethodType {
+    self = [super initWithDelegate:delegate session:session paymentMethodType:paymentMethodType];
+    [AWXSecurityService sharedService];
+    return self;
+}
 
 #pragma mark - Launch Apple Pay flow
 - (void)startPayment {

--- a/Airwallex/Card/AWXCardProvider.m
+++ b/Airwallex/Card/AWXCardProvider.m
@@ -18,6 +18,7 @@
 #import "AWXPaymentMethodOptions.h"
 #import "AWXPaymentMethodRequest.h"
 #import "AWXPaymentMethodResponse.h"
+#import "AWXSecurityService.h"
 #import "AWXSession.h"
 #import "NSObject+Logging.h"
 #import <AirwallexRisk/AirwallexRisk-Swift.h>
@@ -26,6 +27,16 @@
 
 + (BOOL)canHandleSession:(AWXSession *)session paymentMethod:(AWXPaymentMethodType *)paymentMethod {
     return paymentMethod.cardSchemes.count != 0;
+}
+
+- (instancetype)initWithDelegate:(id<AWXProviderDelegate>)delegate session:(AWXSession *)session {
+    return [self initWithDelegate:delegate session:session paymentMethodType:nil];
+}
+
+- (instancetype)initWithDelegate:(id<AWXProviderDelegate>)delegate session:(AWXSession *)session paymentMethodType:(AWXPaymentMethodType *)paymentMethodType {
+    self = [super initWithDelegate:delegate session:session paymentMethodType:paymentMethodType];
+    [AWXSecurityService sharedService];
+    return self;
 }
 
 - (void)handleFlow {

--- a/Airwallex/Security/AWXSecurityService.m
+++ b/Airwallex/Security/AWXSecurityService.m
@@ -8,6 +8,7 @@
 
 #import "AWXSecurityService.h"
 #import "AWXConstants.h"
+#import "NSObject+logging.h"
 #import <RLTMXProfiling/TMXProfiling.h>
 #import <RLTMXProfilingConnections/TMXProfilingConnections.h>
 
@@ -53,15 +54,10 @@
     [self.profiling profileDeviceUsing:@{RLTMXSessionID: sessionId}
                          callbackBlock:^(NSDictionary *result) {
                              RLTMXStatusCode statusCode = [[result valueForKey:RLTMXProfileStatus] integerValue];
-                             dispatch_async(dispatch_get_main_queue(), ^{
-                                 if (statusCode == RLTMXStatusCodeOk) {
-                                     NSString *sessionId = result[RLTMXSessionID];
-                                     completion(sessionId ?: @"");
-                                     return;
-                                 }
-                                 completion(@"");
-                             });
+                             NSString *signifydSessionID = result[RLTMXSessionID];
+                             [self log:@"Session id: %@, Session status: %lu", signifydSessionID, statusCode];
                          }];
+    completion(sessionId);
 #endif
 }
 


### PR DESCRIPTION
- Pass risk session ID regardless of signifyd session ID
- Bring forward initialisation of signifyd to the moment when card/applepay provider is initiated