### PR TITLE
[APAM-55] Card cvc validation

### DIFF
--- a/Airwallex/Airwallex.xcodeproj/project.pbxproj
+++ b/Airwallex/Airwallex.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		180D6F952C5B902A00980400 /* AirwallexRisk.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1803AC8D2C59DB4300BC9FBF /* AirwallexRisk.xcframework */; };
 		1820C9652C78552D006B18C4 /* AWXUIContext+Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1820C9642C78552C006B18C4 /* AWXUIContext+Card.swift */; };
 		1820C96A2C7DDADC006B18C4 /* AWXCardProvider+PaymentConsent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1820C9692C7DDADC006B18C4 /* AWXCardProvider+PaymentConsent.swift */; };
+		1820C9702C85A1C0006B18C4 /* AWXFloatingCvcTextField.h in Headers */ = {isa = PBXBuildFile; fileRef = 1820C96E2C85A1C0006B18C4 /* AWXFloatingCvcTextField.h */; };
+		1820C9712C85A1C0006B18C4 /* AWXFloatingCvcTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = 1820C96F2C85A1C0006B18C4 /* AWXFloatingCvcTextField.m */; };
 		1829B8BB291A538B00D0D2CA /* AWXCardImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = 1829B8B9291A538B00D0D2CA /* AWXCardImageView.h */; };
 		1829B8BC291A538B00D0D2CA /* AWXCardImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 1829B8BA291A538B00D0D2CA /* AWXCardImageView.m */; };
 		1829B8BE291B2D3B00D0D2CA /* PaymentMethodType.json in Resources */ = {isa = PBXBuildFile; fileRef = 1829B8BD291B2D3B00D0D2CA /* PaymentMethodType.json */; };
@@ -363,6 +365,8 @@
 		1820C9642C78552C006B18C4 /* AWXUIContext+Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AWXUIContext+Card.swift"; sourceTree = "<group>"; };
 		1820C9682C7C22B3006B18C4 /* Airwallex.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Airwallex.h; sourceTree = "<group>"; };
 		1820C9692C7DDADC006B18C4 /* AWXCardProvider+PaymentConsent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AWXCardProvider+PaymentConsent.swift"; sourceTree = "<group>"; };
+		1820C96E2C85A1C0006B18C4 /* AWXFloatingCvcTextField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AWXFloatingCvcTextField.h; sourceTree = "<group>"; };
+		1820C96F2C85A1C0006B18C4 /* AWXFloatingCvcTextField.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWXFloatingCvcTextField.m; sourceTree = "<group>"; };
 		1829B8B9291A538B00D0D2CA /* AWXCardImageView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AWXCardImageView.h; sourceTree = "<group>"; };
 		1829B8BA291A538B00D0D2CA /* AWXCardImageView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWXCardImageView.m; sourceTree = "<group>"; };
 		1829B8BD291B2D3B00D0D2CA /* PaymentMethodType.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = PaymentMethodType.json; sourceTree = "<group>"; };
@@ -1107,6 +1111,8 @@
 				5775CF1026E5DF4F00C6AFE3 /* AWXWidgets.m */,
 				1829B8C5291CDEB200D0D2CA /* AWXFloatingCardTextField.h */,
 				1829B8C6291CDEB200D0D2CA /* AWXFloatingCardTextField.m */,
+				1820C96E2C85A1C0006B18C4 /* AWXFloatingCvcTextField.h */,
+				1820C96F2C85A1C0006B18C4 /* AWXFloatingCvcTextField.m */,
 				C844DC7B2C3CE37F0099614C /* NSObject+Logging.h */,
 				C844DC7C2C3CE37F0099614C /* NSObject+Logging.m */,
 			);
@@ -1206,6 +1212,7 @@
 				5775CF5D26E5DF5000C6AFE3 /* AWXPaymentMethodOptions.h in Headers */,
 				184169DB29C4347800B02D96 /* UIColor+ViewCompat.h in Headers */,
 				5775CF3126E5DF4F00C6AFE3 /* AWXPaymentMethodCell.h in Headers */,
+				1820C9702C85A1C0006B18C4 /* AWXFloatingCvcTextField.h in Headers */,
 				5775CF5A26E5DF5000C6AFE3 /* AWXTrackManager.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1833,6 +1840,7 @@
 				5775CF3526E5DF4F00C6AFE3 /* AWXTrackManager.m in Sources */,
 				5775CF4026E5DF5000C6AFE3 /* AWXPaymentMethod.m in Sources */,
 				5775CF4F26E5DF5000C6AFE3 /* AWXForm.m in Sources */,
+				1820C9712C85A1C0006B18C4 /* AWXFloatingCvcTextField.m in Sources */,
 				5775CF2D26E5DF4F00C6AFE3 /* AWXUtils.m in Sources */,
 				1839055A29C02FFE00FE8069 /* Empty.swift in Sources */,
 				5775CF6026E5DF5000C6AFE3 /* AWXWidgets.m in Sources */,

--- a/Airwallex/Card/AWXCardViewController.m
+++ b/Airwallex/Card/AWXCardViewController.m
@@ -19,6 +19,7 @@
 #import "AWXDefaultProvider.h"
 #import "AWXDevice.h"
 #import "AWXFloatingCardTextField.h"
+#import "AWXFloatingCvcTextField.h"
 #import "AWXPaymentIntent.h"
 #import "AWXPaymentIntentResponse.h"
 #import "AWXPaymentMethod.h"
@@ -40,7 +41,7 @@
 @property (strong, nonatomic) AWXFloatingCardTextField *cardNoField;
 @property (strong, nonatomic) AWXFloatingLabelTextField *nameField;
 @property (strong, nonatomic) AWXFloatingLabelTextField *expiresField;
-@property (strong, nonatomic) AWXFloatingLabelTextField *cvcField;
+@property (strong, nonatomic) AWXFloatingCvcTextField *cvcField;
 @property (strong, nonatomic) UISwitch *addressSwitch;
 @property (strong, nonatomic) AWXFloatingLabelTextField *firstNameField;
 @property (strong, nonatomic) AWXFloatingLabelTextField *lastNameField;
@@ -155,8 +156,11 @@ typedef enum {
     _expiresField.delegate = self;
     [cvcStackView addArrangedSubview:_expiresField];
 
-    _cvcField = [AWXFloatingLabelTextField new];
-    _cvcField.fieldType = AWXTextFieldTypeCVC;
+    _cvcField = [AWXFloatingCvcTextField new];
+    _cvcField.validationMessageCallback = ^(NSString *cvc) {
+        return [weakSelf.viewModel validationMessageFromCvc:cvc];
+    };
+    _cvcField.maxLength = _viewModel.cvcLength;
     _cvcField.placeholder = NSLocalizedString(@"CVC / CVV", @"CVC / CVV");
     _expiresField.nextTextField = _cvcField;
     _cvcField.isRequired = YES;

--- a/Airwallex/Card/AWXCardViewController.m
+++ b/Airwallex/Card/AWXCardViewController.m
@@ -55,7 +55,6 @@
 @property (strong, nonatomic) UIStackView *saveCardSwitchContainer;
 @property (strong, nonatomic) UIStackView *container;
 @property (strong, nonatomic) AWXWarningView *warningView;
-@property (nonatomic) AWXBrandType currentBrand;
 
 @property (nonatomic) BOOL saveCard;
 
@@ -118,7 +117,8 @@ typedef enum {
         return [weakSelf.viewModel validationMessageFromCardNumber:cardNumber];
     };
     _cardNoField.brandUpdateCallback = ^(AWXBrandType brand) {
-        weakSelf.currentBrand = brand;
+        weakSelf.viewModel.currentBrand = brand;
+        weakSelf.cvcField.maxLength = weakSelf.viewModel.cvcLength;
         if (weakSelf.saveCard && brand == AWXBrandTypeUnionPay) {
             [weakSelf addUnionPayWarningViewIfNecessary];
         } else {
@@ -357,7 +357,7 @@ typedef enum {
 
 - (void)saveCardSwitchChanged:(id)sender {
     self.saveCard = [(UISwitch *)sender isOn];
-    if (_saveCard && _currentBrand == AWXBrandTypeUnionPay) {
+    if (_saveCard && _viewModel.currentBrand == AWXBrandTypeUnionPay) {
         [self addUnionPayWarningViewIfNecessary];
     } else {
         [_warningView removeFromSuperview];
@@ -536,6 +536,8 @@ typedef enum {
     [self.view addSubview:controller.view];
     [controller didMoveToParentViewController:self];
 }
+
+#pragma mark - AWXFloatingLabelTextFieldDelegate
 
 - (BOOL)floatingLabelTextField:(AWXFloatingLabelTextField *)floatingLabelTextField textFieldShouldBeginEditing:(UITextField *)textField {
     if (textField == self.cardNoField.textField) {

--- a/Airwallex/Card/AWXCardViewModel.h
+++ b/Airwallex/Card/AWXCardViewModel.h
@@ -8,6 +8,7 @@
 
 #import "AWXCardProvider.h"
 #import "AWXCardScheme.h"
+#import "AWXCardValidator.h"
 #import "AWXDefaultActionProvider.h"
 #import "AWXUtils.h"
 
@@ -26,6 +27,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) BOOL isCardSavingEnabled;
 @property (nonatomic, strong, readonly) AWXPlaceDetails *initialBilling;
 @property (nonatomic, strong, nullable) AWXCountry *selectedCountry;
+@property (nonatomic) AWXBrandType currentBrand;
+@property (nonatomic) NSInteger cvcLength;
 
 /**
  Whether card payment is launched directly via public API or payment methods list has been skipped.

--- a/Airwallex/Card/AWXCardViewModel.h
+++ b/Airwallex/Card/AWXCardViewModel.h
@@ -59,6 +59,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable NSString *)validationMessageFromCardNumber:(NSString *)cardNumber;
 
+- (nullable NSString *)validationMessageFromCvc:(NSString *)cvc;
+
 #pragma mark Payment
 
 - (AWXCardProvider *)preparedProviderWithDelegate:(id<AWXProviderDelegate> _Nullable)delegate;

--- a/Airwallex/Card/AWXCardViewModel.m
+++ b/Airwallex/Card/AWXCardViewModel.m
@@ -8,7 +8,6 @@
 
 #import "AWXCardViewModel.h"
 #import "AWXCard.h"
-#import "AWXCardValidator.h"
 #import "AWXCountry.h"
 #import "AWXSession.h"
 
@@ -77,6 +76,10 @@
 
         return YES;
     }
+}
+
+- (void)setCurrentBrand:(AWXBrandType)currentBrand {
+    self.cvcLength = [AWXCardValidator cvcLengthForBrand:currentBrand];
 }
 
 #pragma mark Data creation

--- a/Airwallex/Card/AWXCardViewModel.m
+++ b/Airwallex/Card/AWXCardViewModel.m
@@ -29,6 +29,7 @@
         _selectedCountry = [AWXCountry countryWithCode:session.billing.address.countryCode];
         _supportedCardSchemes = cardSchemes;
         _isLaunchedDirectly = launchDirectly;
+        _cvcLength = [AWXCardValidator cvcLengthForBrand:AWXBrandTypeUnknown];
     }
     return self;
 }
@@ -184,6 +185,16 @@
         return NSLocalizedString(@"Card number is invalid", nil);
     }
     return NSLocalizedString(@"Card number is required", nil);
+}
+
+- (nullable NSString *)validationMessageFromCvc:(NSString *)cvc {
+    if (cvc.length > 0) {
+        if (cvc.length == _cvcLength) {
+            return NULL;
+        }
+        return NSLocalizedString(@"Security code is invalid", nil);
+    }
+    return NSLocalizedString(@"Security code is required", nil);
 }
 
 #pragma mark Payment

--- a/Airwallex/CardTests/AWXCardViewModelTests.m
+++ b/Airwallex/CardTests/AWXCardViewModelTests.m
@@ -331,6 +331,19 @@
     XCTAssertEqualObjects(viewModel.ctaTitle, @"Confirm");
 }
 
+- (void)testSetCurrentBrand {
+    AWXCardViewModel *viewModel = [self mockOneOffViewModel];
+    viewModel.currentBrand = AWXBrandTypeAmex;
+    XCTAssertEqual(viewModel.cvcLength, 4);
+}
+
+- (void)testValidationMessageFromCvc {
+    AWXCardViewModel *viewModel = [self mockOneOffViewModel];
+    XCTAssertNil([viewModel validationMessageFromCvc:@"123"]);
+    XCTAssertEqualObjects([viewModel validationMessageFromCvc:@"12"], @"Security code is invalid");
+    XCTAssertEqualObjects([viewModel validationMessageFromCvc:@""], @"Security code is required");
+}
+
 - (AWXCardViewModel *)mockOneOffViewModel {
     AWXOneOffSession *session = [AWXOneOffSession new];
     return [[AWXCardViewModel alloc] initWithSession:session supportedCardSchemes:NULL launchDirectly:NO];

--- a/Airwallex/Core/Sources/AWXAPIClient.m
+++ b/Airwallex/Core/Sources/AWXAPIClient.m
@@ -216,7 +216,7 @@ static BOOL _localLogFileEnabled = NO;
 - (void)send:(AWXRequest *)request handler:(AWXRequestHandler)handler {
     NSString *method = @"POST";
     NSURL *url = [NSURL URLWithString:request.path relativeToURL:self.configuration.baseURL];
-    [self log:@"ULR request: %@   Class:%@", url.absoluteURL, request.class];
+    [self log:@"URL request: %@   Class:%@", url.absoluteURL, request.class];
 
     if (request.method == AWXHTTPMethodGET) {
         method = @"GET";

--- a/Airwallex/Core/Sources/AWXCard.m
+++ b/Airwallex/Core/Sources/AWXCard.m
@@ -51,7 +51,8 @@
 @implementation AWXCard (Utils)
 
 - (nullable NSString *)validate {
-    if (![[AWXCardValidator sharedCardValidator] isValidCardLength:self.number]) {
+    AWXBrand *brand = [[AWXCardValidator sharedCardValidator] brandForCardNumber:self.number];
+    if (!brand || brand.length != self.number.length) {
         return @"Invalid card number";
     }
     if (self.name.length == 0) {
@@ -60,7 +61,7 @@
     if (self.expiryYear.length == 0 || self.expiryMonth.length == 0) {
         return @"Invalid expires date";
     }
-    if (self.cvc.length == 0) {
+    if (self.cvc.length != [AWXCardValidator cvcLengthForBrand:brand.type]) {
         return @"Invalid CVC / CVV";
     }
     return nil;

--- a/Airwallex/Core/Sources/AWXCardValidator.h
+++ b/Airwallex/Core/Sources/AWXCardValidator.h
@@ -76,6 +76,7 @@ typedef enum : NSUInteger {
 - (nullable AWXBrand *)brandForCardName:(NSString *)name;
 - (BOOL)isValidCardLength:(NSString *)cardNumber;
 + (NSArray<NSNumber *> *)cardNumberFormatForBrand:(AWXBrandType)type;
++ (NSInteger)cvcLengthForBrand:(AWXBrandType)type;
 
 @end
 

--- a/Airwallex/Core/Sources/AWXCardValidator.m
+++ b/Airwallex/Core/Sources/AWXCardValidator.m
@@ -392,6 +392,15 @@
     }
 }
 
++ (NSInteger)cvcLengthForBrand:(AWXBrandType)type {
+    switch (type) {
+    case AWXBrandTypeAmex:
+        return 4;
+    default:
+        return 3;
+    }
+}
+
 #pragma mark - Private methods
 
 - (NSArray<AWXBrand *> *)brandsForCardNumber:(NSString *)cardNumber {

--- a/Airwallex/Core/Sources/AWXFloatingCardTextField.h
+++ b/Airwallex/Core/Sources/AWXFloatingCardTextField.h
@@ -9,6 +9,8 @@
 #import "AWXCardValidator.h"
 #import "AWXWidgets.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  A customized view for card number
  */
@@ -27,3 +29,5 @@ Can make it more explicit when we switch to Swift.
 @property (nonatomic, copy) void (^brandUpdateCallback)(AWXBrandType);
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Airwallex/Core/Sources/AWXFloatingCvcTextField.h
+++ b/Airwallex/Core/Sources/AWXFloatingCvcTextField.h
@@ -1,0 +1,21 @@
+//
+//  AWXFloatingCvcTextField.h
+//  Core
+//
+//  Created by Hector.Huang on 2024/9/2.
+//  Copyright © 2024 Airwallex. All rights reserved.
+//
+
+#import "AWXWidgets.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface AWXFloatingCvcTextField : AWXFloatingLabelTextField
+
+@property (nonatomic) NSInteger maxLength;
+
+@property (nonatomic, copy, nullable) NSString * (^validationMessageCallback)(NSString *);
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Airwallex/Core/Sources/AWXFloatingCvcTextField.m
+++ b/Airwallex/Core/Sources/AWXFloatingCvcTextField.m
@@ -1,0 +1,35 @@
+//
+//  AWXFloatingCvcTextField.m
+//  Core
+//
+//  Created by Hector.Huang on 2024/9/2.
+//  Copyright © 2024 Airwallex. All rights reserved.
+//
+
+#import "AWXFloatingCvcTextField.h"
+
+@implementation AWXFloatingCvcTextField
+
+#pragma mark Override parent methods
+
+- (instancetype)init {
+    self = [super init];
+    self.fieldType = AWXTextFieldTypeCVC;
+    return self;
+}
+
+- (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string {
+    self.errorText = nil;
+    NSString *text = [textField.text stringByReplacingCharactersInRange:range withString:string];
+    text = [text substringToIndex:MIN(text.length, _maxLength)];
+    text.length > 0 ? [self activateAnimated:YES] : [self deactivateAnimated:YES];
+
+    [self setText:text animated:YES];
+    return NO;
+}
+
+- (void)textFieldDidEndEditing:(UITextField *)textField {
+    self.errorText = _validationMessageCallback(textField.text);
+}
+
+@end

--- a/Airwallex/Core/Sources/AWXWidgets.h
+++ b/Airwallex/Core/Sources/AWXWidgets.h
@@ -54,7 +54,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) NSString *prefixText;
 @property (nonatomic) AWXTextFieldType fieldType;
 @property (nonatomic, weak) AWXFloatingLabelTextField *nextTextField;
-@property (nonatomic) NSInteger maxLength;
 
 - (NSString *)text;
 - (void)setText:(NSString *)text animated:(BOOL)animated;

--- a/Airwallex/Core/Sources/AWXWidgets.h
+++ b/Airwallex/Core/Sources/AWXWidgets.h
@@ -54,6 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) NSString *prefixText;
 @property (nonatomic) AWXTextFieldType fieldType;
 @property (nonatomic, weak) AWXFloatingLabelTextField *nextTextField;
+@property (nonatomic) NSInteger maxLength;
 
 - (NSString *)text;
 - (void)setText:(NSString *)text animated:(BOOL)animated;

--- a/Airwallex/Core/Sources/AWXWidgets.m
+++ b/Airwallex/Core/Sources/AWXWidgets.m
@@ -319,7 +319,7 @@
             text = [string substringToIndex:string.length - 1];
         }
     } else if (self.fieldType == AWXTextFieldTypeCVC) {
-        text = [text substringToIndex:MIN(text.length, 4)];
+        text = [text substringToIndex:MIN(text.length, _maxLength)];
     }
     text.length > 0 ? [self activateAnimated:YES] : [self deactivateAnimated:YES];
     [self setText:text animated:YES];

--- a/Airwallex/Core/Sources/AWXWidgets.m
+++ b/Airwallex/Core/Sources/AWXWidgets.m
@@ -74,6 +74,7 @@
         _errorLabel = [UILabel new];
         _errorLabel.font = [UIFont caption1Font];
         _errorLabel.translatesAutoresizingMaskIntoConstraints = NO;
+        _errorLabel.numberOfLines = 0;
         [self addSubview:_errorLabel];
 
         [self setupLayouts];
@@ -304,7 +305,7 @@
 
 - (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string {
     NSString *text = [textField.text stringByReplacingCharactersInRange:range withString:string];
-    if (!(self.fieldType == AWXTextFieldTypeExpires || self.fieldType == AWXTextFieldTypeCVC)) {
+    if (!(self.fieldType == AWXTextFieldTypeExpires)) {
         if (self.delegate && [self.delegate respondsToSelector:@selector(floatingLabelTextField:textDidChange:)]) {
             [self.delegate floatingLabelTextField:self textDidChange:text];
         }
@@ -318,8 +319,6 @@
             NSString *string = [textField.text stringByRemovingIllegalCharacters];
             text = [string substringToIndex:string.length - 1];
         }
-    } else if (self.fieldType == AWXTextFieldTypeCVC) {
-        text = [text substringToIndex:MIN(text.length, _maxLength)];
     }
     text.length > 0 ? [self activateAnimated:YES] : [self deactivateAnimated:YES];
     [self setText:text animated:YES];
@@ -379,10 +378,10 @@
                 isValidYear = year.integerValue > currentYear;
             }
             if (!(isValidYear && isValidMonth)) {
-                errorMessage = NSLocalizedString(@"Card’s expiration date is invalid.", nil);
+                errorMessage = NSLocalizedString(@"Card’s expiration date is invalid", nil);
             }
         } else {
-            errorMessage = NSLocalizedString(@"Card’s expiration date is invalid.", nil);
+            errorMessage = NSLocalizedString(@"Card’s expiration date is invalid", nil);
         }
     } else {
         errorMessage = NSLocalizedString(@"Expiry date is required", nil);
@@ -428,9 +427,6 @@
         break;
     case AWXTextFieldTypeExpires:
         [self validateExpires:textField.text];
-        break;
-    case AWXTextFieldTypeCVC:
-        self.errorText = textField.text.length > 0 ? nil : NSLocalizedString(@"Security code is required", nil);
         break;
     default:
         self.errorText = textField.text.length > 0 ? nil : self.defaultErrorMessage;

--- a/Airwallex/CoreTests/Models/AWXCardTest.m
+++ b/Airwallex/CoreTests/Models/AWXCardTest.m
@@ -28,10 +28,20 @@
     XCTAssertNotNil(card.fingerprint);
 }
 
-- (void)testValidation {
+- (void)testValidationWhenInvalidCardNumber {
     AWXCard *card = [AWXCard new];
     card.number = @"12345";
     XCTAssertEqualObjects([card validate], @"Invalid card number");
+}
+
+- (void)testValidationWhenInvalidCvc {
+    AWXCard *card = [AWXCard new];
+    card.number = @"378282246310005";
+    card.name = @"name";
+    card.expiryYear = @"25";
+    card.expiryMonth = @"8";
+    card.cvc = @"123";
+    XCTAssertEqualObjects([card validate], @"Invalid CVC / CVV");
 }
 
 @end

--- a/Airwallex/CoreTests/Tools/AWXCardValidatorTest.m
+++ b/Airwallex/CoreTests/Tools/AWXCardValidatorTest.m
@@ -62,4 +62,10 @@
     XCTAssertEqual([validator maxLengthForCardNumber:@"3643"], 19);
 }
 
+- (void)testCvcLengthForBrand {
+    XCTAssertEqual([AWXCardValidator cvcLengthForBrand:AWXBrandTypeAmex], 4);
+    XCTAssertEqual([AWXCardValidator cvcLengthForBrand:AWXBrandTypeMastercard], 3);
+    XCTAssertEqual([AWXCardValidator cvcLengthForBrand:AWXBrandTypeUnknown], 3);
+}
+
 @end

--- a/Examples/Examples/Cart/CartViewController.m
+++ b/Examples/Examples/Cart/CartViewController.m
@@ -8,13 +8,13 @@
 
 #import "CartViewController.h"
 #import "APIClient.h"
-#import "Airwallex-Swift.h"
 #import "AirwallexExamplesKeys.h"
 #import "OptionsViewController.h"
 #import "ProductCell.h"
 #import "ShippingCell.h"
 #import "TotalCell.h"
 #import "UIViewController+Utils.h"
+#import <Airwallex/Airwallex-Swift.h>
 #import <Airwallex/ApplePay.h>
 #import <Airwallex/Core.h>
 #import <SafariServices/SFSafariViewController.h>

--- a/Examples/Examples/Cart/CartViewController.m
+++ b/Examples/Examples/Cart/CartViewController.m
@@ -8,13 +8,13 @@
 
 #import "CartViewController.h"
 #import "APIClient.h"
+#import "Airwallex-Swift.h"
 #import "AirwallexExamplesKeys.h"
 #import "OptionsViewController.h"
 #import "ProductCell.h"
 #import "ShippingCell.h"
 #import "TotalCell.h"
 #import "UIViewController+Utils.h"
-#import <Airwallex-Swift.h>
 #import <Airwallex/ApplePay.h>
 #import <Airwallex/Core.h>
 #import <SafariServices/SFSafariViewController.h>


### PR DESCRIPTION
This improves card cvc validation by:
- Limit input length according to card scheme
- Show different validation message
- Fix layout that cvc error message is truncated