### PR TITLE
[APAM-57] Add redirect pay low-level api

### DIFF
--- a/Airwallex.podspec
+++ b/Airwallex.podspec
@@ -35,7 +35,7 @@ Pod::Spec.new do |s|
   
   s.subspec 'Redirect' do |plugin|
     plugin.dependency 'Airwallex/Core'
-    plugin.source_files = 'Airwallex/Redirect/**/*.{h,m}'
+    plugin.source_files = 'Airwallex/Redirect/**/*.{swift,h,m}'
     plugin.public_header_files = 'Airwallex/Redirect/*.h'
   end
   

--- a/Airwallex/Airwallex.xcodeproj/project.pbxproj
+++ b/Airwallex/Airwallex.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		1829B8C4291B3B7000D0D2CA /* AWXCardProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1829B8C3291B3B7000D0D2CA /* AWXCardProviderTests.m */; };
 		1829B8C7291CDEB200D0D2CA /* AWXFloatingCardTextField.h in Headers */ = {isa = PBXBuildFile; fileRef = 1829B8C5291CDEB200D0D2CA /* AWXFloatingCardTextField.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1829B8C8291CDEB200D0D2CA /* AWXFloatingCardTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = 1829B8C6291CDEB200D0D2CA /* AWXFloatingCardTextField.m */; };
+		182F1CF32CA16C23000B993D /* AWXRedirectActionProvider+PaymentIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182F1CF22CA16C23000B993D /* AWXRedirectActionProvider+PaymentIntent.swift */; };
 		183214752BA187A800FC97B9 /* AWXNextActionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 183214732BA187A800FC97B9 /* AWXNextActionHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		183214762BA187A800FC97B9 /* AWXNextActionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 183214742BA187A800FC97B9 /* AWXNextActionHandler.m */; };
 		1839054F29C01AE900FE8069 /* AWXAnalyticsLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 1839054D29C01AE900FE8069 /* AWXAnalyticsLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -375,6 +376,7 @@
 		1829B8C3291B3B7000D0D2CA /* AWXCardProviderTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWXCardProviderTests.m; sourceTree = "<group>"; };
 		1829B8C5291CDEB200D0D2CA /* AWXFloatingCardTextField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AWXFloatingCardTextField.h; sourceTree = "<group>"; };
 		1829B8C6291CDEB200D0D2CA /* AWXFloatingCardTextField.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWXFloatingCardTextField.m; sourceTree = "<group>"; };
+		182F1CF22CA16C23000B993D /* AWXRedirectActionProvider+PaymentIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AWXRedirectActionProvider+PaymentIntent.swift"; sourceTree = "<group>"; };
 		183214732BA187A800FC97B9 /* AWXNextActionHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AWXNextActionHandler.h; sourceTree = "<group>"; };
 		183214742BA187A800FC97B9 /* AWXNextActionHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWXNextActionHandler.m; sourceTree = "<group>"; };
 		1839054D29C01AE900FE8069 /* AWXAnalyticsLogger.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AWXAnalyticsLogger.h; sourceTree = "<group>"; };
@@ -1034,6 +1036,7 @@
 				57E73718272AC043009905DC /* AWXSchemaProvider.m */,
 				5775CF9226E5E28D00C6AFE3 /* AWXRedirectActionProvider.h */,
 				5775CF9326E5E28D00C6AFE3 /* AWXRedirectActionProvider.m */,
+				182F1CF22CA16C23000B993D /* AWXRedirectActionProvider+PaymentIntent.swift */,
 				5775CEAD26E5DF3300C6AFE3 /* Redirect.h */,
 				5775CEAE26E5DF3300C6AFE3 /* Info.plist */,
 			);
@@ -1511,6 +1514,7 @@
 					};
 					5775CEAA26E5DF3300C6AFE3 = {
 						CreatedOnToolsVersion = 12.5.1;
+						LastSwiftMigration = 1540;
 					};
 					5775CEB226E5DF3300C6AFE3 = {
 						CreatedOnToolsVersion = 12.5.1;
@@ -1977,6 +1981,7 @@
 				57E7371A272AC043009905DC /* AWXSchemaProvider.m in Sources */,
 				1803601D2873CAE2003EA943 /* AWXPaymentFormViewModel.m in Sources */,
 				5775CF9626E5E28D00C6AFE3 /* AWXPaymentFormViewController.m in Sources */,
+				182F1CF32CA16C23000B993D /* AWXRedirectActionProvider+PaymentIntent.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2534,6 +2539,7 @@
 		5775CEBD26E5DF3300C6AFE3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -2550,6 +2556,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -2557,6 +2565,7 @@
 		5775CEBE26E5DF3300C6AFE3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -2573,6 +2582,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -2581,6 +2591,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = FC522BD223B734E323755856 /* Pods-RedirectTests.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = K294E2HD3N;
 				INFOPLIST_FILE = RedirectTests/Info.plist;
@@ -2594,6 +2605,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F9330DB1F34C6DD83245F7CF /* Pods-RedirectTests.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = K294E2HD3N;
 				INFOPLIST_FILE = RedirectTests/Info.plist;

--- a/Airwallex/Card/AWXCardProvider+PaymentConsent.swift
+++ b/Airwallex/Card/AWXCardProvider+PaymentConsent.swift
@@ -9,7 +9,8 @@
 import UIKit
 
 public extension AWXCardProvider {
-    @objc func confirmPaymentIntent(with paymentConsent: AWXPaymentConsent) {
+    @objc(confirmPaymentIntentWithPaymentConsent:)
+    func confirmPaymentIntent(with paymentConsent: AWXPaymentConsent) {
         guard let hostViewController = delegate?.hostViewController?() else {
             fatalError("hostViewController of AWXProviderDelegate is not provided")
         }

--- a/Airwallex/Card/AWXCardProvider+PaymentConsent.swift
+++ b/Airwallex/Card/AWXCardProvider+PaymentConsent.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 public extension AWXCardProvider {
-    @objc func confirmPaymentIntentWithPaymentConsent(_ paymentConsent: AWXPaymentConsent) {
+    @objc func confirmPaymentIntent(with paymentConsent: AWXPaymentConsent) {
         guard let hostViewController = delegate?.hostViewController?() else {
             fatalError("hostViewController of AWXProviderDelegate is not provided")
         }

--- a/Airwallex/CardTests/AWXCardProviderTests.m
+++ b/Airwallex/CardTests/AWXCardProviderTests.m
@@ -131,7 +131,7 @@
     consent.Id = @"consentID";
     consent.paymentMethod = method;
 
-    [provider confirmPaymentIntentWithPaymentConsent:consent];
+    [provider confirmPaymentIntentWith:consent];
     OCMVerify(times(1), [mockViewController presentViewController:[OCMArg isKindOfClass:[UINavigationController class]]
                                                          animated:YES
                                                        completion:nil]);
@@ -147,7 +147,7 @@
     AWXPaymentConsent *consent = [AWXPaymentConsent new];
     consent.Id = @"consentID";
 
-    [provider confirmPaymentIntentWithPaymentConsent:consent];
+    [provider confirmPaymentIntentWith:consent];
     OCMVerify(times(1), [client send:[OCMArg checkWithBlock:^BOOL(id obj) {
                                     AWXConfirmPaymentIntentRequest *request = obj;
                                     XCTAssertEqual(request.paymentConsent.Id, @"consentID");

--- a/Airwallex/CardTests/AWXCardProviderTests.m
+++ b/Airwallex/CardTests/AWXCardProviderTests.m
@@ -131,7 +131,7 @@
     consent.Id = @"consentID";
     consent.paymentMethod = method;
 
-    [provider confirmPaymentIntentWith:consent];
+    [provider confirmPaymentIntentWithPaymentConsent:consent];
     OCMVerify(times(1), [mockViewController presentViewController:[OCMArg isKindOfClass:[UINavigationController class]]
                                                          animated:YES
                                                        completion:nil]);
@@ -147,7 +147,7 @@
     AWXPaymentConsent *consent = [AWXPaymentConsent new];
     consent.Id = @"consentID";
 
-    [provider confirmPaymentIntentWith:consent];
+    [provider confirmPaymentIntentWithPaymentConsent:consent];
     OCMVerify(times(1), [client send:[OCMArg checkWithBlock:^BOOL(id obj) {
                                     AWXConfirmPaymentIntentRequest *request = obj;
                                     XCTAssertEqual(request.paymentConsent.Id, @"consentID");

--- a/Airwallex/Core/Sources/AWXConstants.h
+++ b/Airwallex/Core/Sources/AWXConstants.h
@@ -26,6 +26,11 @@ extern AWXCardBrand const AWXCardBrandJCB;
 extern AWXCardBrand const AWXCardBrandDinersClub;
 extern AWXCardBrand const AWXCardBrandUnionPay;
 
+typedef NSString *AWXPaymentMethodFlow NS_TYPED_EXTENSIBLE_ENUM;
+extern AWXPaymentMethodFlow const AWXPaymentMethodFlowApp;
+extern AWXPaymentMethodFlow const AWXPaymentMethodFlowWeb;
+extern AWXPaymentMethodFlow const AWXPaymentMethodFlowQrcode;
+
 typedef NS_CLOSED_ENUM(NSInteger, AirwallexSDKMode) {
     AirwallexSDKDemoMode,
     AirwallexSDKStagingMode,

--- a/Airwallex/Core/Sources/AWXConstants.m
+++ b/Airwallex/Core/Sources/AWXConstants.m
@@ -45,6 +45,10 @@ AWXCardBrand const AWXCardBrandJCB = @"jcb";
 AWXCardBrand const AWXCardBrandDinersClub = @"diners";
 AWXCardBrand const AWXCardBrandUnionPay = @"unionpay";
 
+AWXPaymentMethodFlow const AWXPaymentMethodFlowApp = @"inapp";
+AWXPaymentMethodFlow const AWXPaymentMethodFlowWeb = @"mweb";
+AWXPaymentMethodFlow const AWXPaymentMethodFlowQrcode = @"webqr";
+
 NSArray *AWXCardSupportedBrands(void) {
     return @[@(AWXBrandTypeVisa), @(AWXBrandTypeMastercard), @(AWXBrandTypeAmex), @(AWXBrandTypeUnionPay), @(AWXBrandTypeJCB), @(AWXBrandTypeDinersClub), @(AWXBrandTypeDiscover)];
 };

--- a/Airwallex/Core/Sources/AWXDefaultProvider.h
+++ b/Airwallex/Core/Sources/AWXDefaultProvider.h
@@ -159,6 +159,19 @@ NS_ASSUME_NONNULL_BEGIN
                                        device:(nullable AWXDevice *)device;
 
 /**
+ Confirm the payment intent with payment method and consent.
+
+ @param paymentMethod The payment method info.
+ @param paymentConsent The payment consent info.
+ @param device The current device info.
+ @param flow The payment method flow.
+ */
+- (void)confirmPaymentIntentWithPaymentMethod:(AWXPaymentMethod *)paymentMethod
+                               paymentConsent:(nullable AWXPaymentConsent *)paymentConsent
+                                       device:(nullable AWXDevice *)device
+                                         flow:(AWXPaymentMethodFlow)flow;
+
+/**
  Confirm the payment intent with payment method and consent as well as a custom completion block.
 
  @param paymentMethod The payment method info.

--- a/Airwallex/Core/Sources/AWXDefaultProvider.m
+++ b/Airwallex/Core/Sources/AWXDefaultProvider.m
@@ -82,8 +82,8 @@
 }
 
 - (void)confirmPaymentIntentWithPaymentMethod:(AWXPaymentMethod *)paymentMethod
-                               paymentConsent:(AWXPaymentConsent *)paymentConsent
-                                       device:(AWXDevice *)device
+                               paymentConsent:(nullable AWXPaymentConsent *)paymentConsent
+                                       device:(nullable AWXDevice *)device
                                          flow:(AWXPaymentMethodFlow)flow {
     __weak __typeof(self) weakSelf = self;
     [self confirmPaymentIntentWithPaymentMethodInternal:paymentMethod

--- a/Airwallex/Core/Sources/Internal/AWXPaymentMethodRequest.m
+++ b/Airwallex/Core/Sources/Internal/AWXPaymentMethodRequest.m
@@ -65,7 +65,7 @@
         self.pageNum = 0;
         self.pageSize = 10;
         self.resources = YES;
-        self.flow = @"inapp";
+        self.flow = AWXPaymentMethodFlowApp;
     }
     return self;
 }
@@ -116,7 +116,7 @@
 - (instancetype)init {
     self = [super init];
     if (self) {
-        self.flow = @"inapp";
+        self.flow = AWXPaymentMethodFlowApp;
     }
     return self;
 }

--- a/Airwallex/CoreTests/AWXDefaultProviderTest.m
+++ b/Airwallex/CoreTests/AWXDefaultProviderTest.m
@@ -84,8 +84,7 @@ NSString *const kMockKey = @"MOCK";
     OCMVerify(times(1), [self.providerMock confirmPaymentIntentWithPaymentMethod:[OCMArg any]
                                                                   paymentConsent:[OCMArg any]
                                                                           device:[OCMArg any]
-                                                                      completion:[OCMArg any]]);
-    OCMVerify(times(1), [self.providerMock completeWithResponse:self.response error:self.error]);
+                                                                            flow:AWXPaymentMethodFlowApp]);
 }
 
 - (void)testConfirmPaymentIntentWithCard {
@@ -291,6 +290,7 @@ NSString *const kMockKey = @"MOCK";
                                                  paymentConsent:[OCMArg any]
                                                          device:[OCMArg any]
                                                      completion:([OCMArg invokeBlockWithArgs:response, error, nil])]);
+
     if (hasError) {
         OCMStub([providerMock createPaymentConsentWithPaymentMethod:[OCMArg any]
                                                          customerId:[OCMArg any]

--- a/Airwallex/Redirect/AWXRedirectActionProvider+PaymentIntent.swift
+++ b/Airwallex/Redirect/AWXRedirectActionProvider+PaymentIntent.swift
@@ -1,0 +1,18 @@
+//
+//  AWXRedirectActionProvider+PaymentIntent.swift
+//  Redirect
+//
+//  Created by Hector.Huang on 2024/9/23.
+//  Copyright © 2024 Airwallex. All rights reserved.
+//
+
+import Foundation
+
+public extension AWXRedirectActionProvider {
+    @objc func confirmPaymentIntent(with paymentMethodName: String, additionalInfo: Dictionary<String, String>? = nil) {
+        let paymentMethod = AWXPaymentMethod()
+        paymentMethod.type = paymentMethodName
+        paymentMethod.additionalParams = additionalInfo
+        confirmPaymentIntent(with: paymentMethod, paymentConsent: nil, device: nil)
+    }
+}

--- a/Airwallex/Redirect/AWXRedirectActionProvider+PaymentIntent.swift
+++ b/Airwallex/Redirect/AWXRedirectActionProvider+PaymentIntent.swift
@@ -9,7 +9,8 @@
 import Foundation
 
 public extension AWXRedirectActionProvider {
-    @objc func confirmPaymentIntent(
+    @objc(confirmPaymentIntentWithPaymentMethodName:additionalInfo:flow:)
+    func confirmPaymentIntent(
         with paymentMethodName: String,
         additionalInfo: Dictionary<String, String>? = nil,
         flow: AWXPaymentMethodFlow = .app

--- a/Airwallex/Redirect/AWXRedirectActionProvider+PaymentIntent.swift
+++ b/Airwallex/Redirect/AWXRedirectActionProvider+PaymentIntent.swift
@@ -9,10 +9,14 @@
 import Foundation
 
 public extension AWXRedirectActionProvider {
-    @objc func confirmPaymentIntent(with paymentMethodName: String, additionalInfo: Dictionary<String, String>? = nil) {
+    @objc func confirmPaymentIntent(
+        with paymentMethodName: String,
+        additionalInfo: Dictionary<String, String>? = nil,
+        flow: AWXPaymentMethodFlow = .app
+    ) {
         let paymentMethod = AWXPaymentMethod()
         paymentMethod.type = paymentMethodName
         paymentMethod.additionalParams = additionalInfo
-        confirmPaymentIntent(with: paymentMethod, paymentConsent: nil, device: nil)
+        confirmPaymentIntent(with: paymentMethod, paymentConsent: nil, device: nil, flow: flow)
     }
 }

--- a/Airwallex/Redirect/AWXRedirectActionProvider.m
+++ b/Airwallex/Redirect/AWXRedirectActionProvider.m
@@ -14,7 +14,9 @@
 @implementation AWXRedirectActionProvider
 
 - (void)handleNextAction:(AWXConfirmPaymentNextAction *)nextAction {
-    [self.delegate provider:self shouldPresentViewController:nil forceToDismiss:YES withAnimation:YES];
+    if ([self.delegate respondsToSelector:@selector(provider:shouldPresentViewController:forceToDismiss:withAnimation:)]) {
+        [self.delegate provider:self shouldPresentViewController:nil forceToDismiss:YES withAnimation:YES];
+    }
 
     NSURL *url = [NSURL URLWithString:nextAction.url];
     if (url) {

--- a/Airwallex/Redirect/AWXSchemaProvider.m
+++ b/Airwallex/Redirect/AWXSchemaProvider.m
@@ -108,9 +108,9 @@
     NSMutableDictionary *params = [NSMutableDictionary dictionary];
     AWXField *flowField = [hiddenFields filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"name == %@", @"flow"]].firstObject;
     if (flowField) {
-        BOOL isInApp = [flowField.candidates filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"value == %@", @"inapp"]].count > 0;
+        BOOL isInApp = [flowField.candidates filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"value == %@", AWXPaymentMethodFlowApp]].count > 0;
         if (isInApp) {
-            params[@"flow"] = @"inapp";
+            params[@"flow"] = AWXPaymentMethodFlowApp;
         } else {
             AWXCandidate *first = flowField.candidates.firstObject;
             if (first) {

--- a/Airwallex/RedirectTests/AWXRedirectActionProviderTests.m
+++ b/Airwallex/RedirectTests/AWXRedirectActionProviderTests.m
@@ -97,7 +97,7 @@
     AWXProviderDelegateSpy *delegate = [AWXProviderDelegateSpy new];
     AWXRedirectActionProvider *provider = [[AWXRedirectActionProvider alloc] initWithDelegate:delegate session:[AWXOneOffSession new]];
 
-    [provider confirmPaymentIntentWith:@"paypal" additionalInfo:@{@"name": @"John"} flow:AWXPaymentMethodFlowWeb];
+    [provider confirmPaymentIntentWithPaymentMethodName:@"paypal" additionalInfo:@{@"name": @"John"} flow:AWXPaymentMethodFlowWeb];
     NSDictionary *dict = @{@"name": @"John", @"flow": @"mweb", @"os_type": @"ios"};
     OCMVerify(times(1), [client send:[OCMArg checkWithBlock:^BOOL(id obj) {
                                     AWXConfirmPaymentIntentRequest *request = obj;

--- a/Examples/Examples/AirwallexExamplesKeys.h
+++ b/Examples/Examples/AirwallexExamplesKeys.h
@@ -18,6 +18,7 @@ static NSString *const kCachedRequiresCVC = @"kCachedRequiresCVC";
 static NSString *const kCachedForce3DS = @"kCachedForce3DS";
 static NSString *const kCachedAutoCapture = @"kCachedAutoCapture";
 static NSString *const kCachedApplePayMethodOnly = @"kCachedApplePayMethodOnly";
+static NSString *const kCachedRedirectPayOnly = @"kCachedRedirectPayOnly";
 static NSString *const kCachedCardMethodOnly = @"kCachedCardMethodOnly";
 static NSString *const kCachedCustomerID = @"kCachedCustomerID";
 static NSString *const kCachedApiKey = @"kCachedApiKey";
@@ -42,6 +43,7 @@ typedef NS_CLOSED_ENUM(NSInteger, AirwallexCheckoutMode) {
 @property (nonatomic) BOOL force3DS;
 @property (nonatomic) BOOL autoCapture;
 @property (nonatomic) BOOL applePayMethodOnly;
+@property (nonatomic) BOOL redirectPayOnly;
 @property (nonatomic) BOOL cardMethodOnly;
 @property (nonatomic, strong, nullable) NSString *customerId;
 @property (nonatomic, strong) NSString *apiKey;

--- a/Examples/Examples/AirwallexExamplesKeys.m
+++ b/Examples/Examples/AirwallexExamplesKeys.m
@@ -60,6 +60,7 @@
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:kCachedReturnURL];
     [[NSUserDefaults standardUserDefaults] setBool:YES forKey:kCachedAutoCapture];
     [[NSUserDefaults standardUserDefaults] setBool:NO forKey:kCachedApplePayMethodOnly];
+    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:kCachedRedirectPayOnly];
     [[NSUserDefaults standardUserDefaults] setBool:NO forKey:kCachedCardMethodOnly];
     [[NSUserDefaults standardUserDefaults] synchronize];
 
@@ -75,6 +76,7 @@
     self.force3DS = [userDefaults boolForKey:kCachedForce3DS];
     self.autoCapture = [userDefaults boolForKey:kCachedAutoCapture];
     self.applePayMethodOnly = [userDefaults boolForKey:kCachedApplePayMethodOnly];
+    self.redirectPayOnly = [userDefaults boolForKey:kCachedRedirectPayOnly];
     self.cardMethodOnly = [userDefaults boolForKey:kCachedCardMethodOnly];
     self.customerId = [userDefaults stringForKey:kCachedCustomerID];
 
@@ -122,6 +124,11 @@
 - (void)setApplePayMethodOnly:(BOOL)applePayMethodOnly {
     _applePayMethodOnly = applePayMethodOnly;
     [[NSUserDefaults standardUserDefaults] setBool:applePayMethodOnly forKey:kCachedApplePayMethodOnly];
+}
+
+- (void)setRedirectPayOnly:(BOOL)redirectPayOnly {
+    _redirectPayOnly = redirectPayOnly;
+    [[NSUserDefaults standardUserDefaults] setBool:redirectPayOnly forKey:kCachedRedirectPayOnly];
 }
 
 - (void)setCardMethodOnly:(BOOL)cardMethodOnly {

--- a/Examples/Examples/Cart/CartViewController.swift
+++ b/Examples/Examples/Cart/CartViewController.swift
@@ -232,7 +232,7 @@ class CartViewController: UIViewController {
         // Redirect Pay low-level API integration
         if (UserDefaults.standard.bool(forKey: kCachedRedirectPayOnly)) {
             let redirectProvider = AWXRedirectActionProvider(delegate: self, session: session)
-            redirectProvider.confirmPaymentIntent(with: "alipayhk")
+            redirectProvider.confirmPaymentIntent(with: "paypal", additionalInfo: ["shopper_name": "Hector", "country_code": "CN"])
             self.redirectProvider = redirectProvider
             return
         }

--- a/Examples/Examples/Cart/CartViewController.swift
+++ b/Examples/Examples/Cart/CartViewController.swift
@@ -19,6 +19,7 @@ class CartViewController: UIViewController {
     var shipping: AWXPlaceDetails?
     var apiClient: APIClient!
     private var applePayProvider: AWXApplePayProvider?
+    private var redirectProvider: AWXRedirectActionProvider?
     
     private var checkoutMode: AirwallexCheckoutMode? {
         AirwallexCheckoutMode(rawValue: UserDefaults.standard.integer(forKey: kCachedCheckoutMode))
@@ -117,6 +118,8 @@ class CartViewController: UIViewController {
 
         let checkoutTitle = if (UserDefaults.standard.bool(forKey: kCachedApplePayMethodOnly)) {
             "Pay"
+        } else if (UserDefaults.standard.bool(forKey: kCachedRedirectPayOnly)) {
+            "Pay by redirection"
         } else if (UserDefaults.standard.bool(forKey: kCachedCardMethodOnly)) {
             "Pay by card"
         } else {
@@ -224,6 +227,13 @@ class CartViewController: UIViewController {
             let applePayProvider = AWXApplePayProvider(delegate: self, session: session)
             applePayProvider.startPayment()
             self.applePayProvider = applePayProvider
+            return
+        }
+        // Redirect Pay low-level API integration
+        if (UserDefaults.standard.bool(forKey: kCachedRedirectPayOnly)) {
+            let redirectProvider = AWXRedirectActionProvider(delegate: self, session: session)
+            redirectProvider.confirmPaymentIntent(with: "alipayhk")
+            self.redirectProvider = redirectProvider
             return
         }
         

--- a/Examples/Examples/Cart/OptionsViewController.m
+++ b/Examples/Examples/Cart/OptionsViewController.m
@@ -38,6 +38,7 @@
 @property (weak, nonatomic) IBOutlet UISwitch *threeDSSwitch;
 @property (weak, nonatomic) IBOutlet UISwitch *autoCaptureSwitch;
 @property (weak, nonatomic) IBOutlet UISwitch *applePayOnlySwitch;
+@property (weak, nonatomic) IBOutlet UISwitch *redirectPayOnlySwitch;
 @property (weak, nonatomic) IBOutlet UISwitch *cardOnlySwitch;
 @property (weak, nonatomic) IBOutlet UITextField *customerIdTextField;
 @property (weak, nonatomic) IBOutlet UIButton *clearCustomerIdButton;
@@ -189,6 +190,10 @@
     [AirwallexExamplesKeys shared].applePayMethodOnly = self.applePayOnlySwitch.isOn;
 }
 
+- (IBAction)redirectPayOnlySwitchPressed:(id)sender {
+    [AirwallexExamplesKeys shared].redirectPayOnly = self.redirectPayOnlySwitch.isOn;
+}
+
 - (IBAction)cardOnlySwitchPressed:(id)sender {
     [AirwallexExamplesKeys shared].cardMethodOnly = self.cardOnlySwitch.isOn;
 }
@@ -286,6 +291,9 @@
 
     BOOL applePayMethodOnly = [AirwallexExamplesKeys shared].applePayMethodOnly;
     self.applePayOnlySwitch.on = applePayMethodOnly;
+
+    BOOL redirectPayOnly = [AirwallexExamplesKeys shared].redirectPayOnly;
+    self.redirectPayOnlySwitch.on = redirectPayOnly;
 
     BOOL cardMethodOnly = [AirwallexExamplesKeys shared].cardMethodOnly;
     self.cardOnlySwitch.on = cardMethodOnly;

--- a/Examples/Examples/Resources/Base.lproj/Main.storyboard
+++ b/Examples/Examples/Resources/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="pG9-fq-6li">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="pG9-fq-6li">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -581,10 +581,10 @@
                                 <rect key="frame" x="0.0" y="59" width="393" height="759"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iM6-7j-oWC">
-                                        <rect key="frame" x="0.0" y="0.0" width="393" height="1228.6666666666667"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="393" height="1275.6666666666667"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="P74-f6-EbX">
-                                                <rect key="frame" x="16" y="16" width="361" height="1196.6666666666667"/>
+                                                <rect key="frame" x="16" y="16" width="361" height="1243.6666666666667"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Environment" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="I3F-HC-rpy">
                                                         <rect key="frame" x="0.0" y="0.0" width="361" height="24"/>
@@ -702,8 +702,25 @@
                                                             </switch>
                                                         </subviews>
                                                     </stackView>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TNM-bj-fLG">
+                                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yDg-5S-mW6">
                                                         <rect key="frame" x="0.0" y="447.66666666666663" width="361" height="31"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Redirect Pay Only" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dFW-5I-euS">
+                                                                <rect key="frame" x="0.0" y="0.0" width="312" height="31"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                <color key="textColor" name="Black Text Color"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="WuA-yK-FcQ">
+                                                                <rect key="frame" x="312" y="0.0" width="51" height="31"/>
+                                                                <connections>
+                                                                    <action selector="redirectPayOnlySwitchPressed:" destination="3dc-1g-4U7" eventType="valueChanged" id="LFs-hw-gxI"/>
+                                                                </connections>
+                                                            </switch>
+                                                        </subviews>
+                                                    </stackView>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TNM-bj-fLG">
+                                                        <rect key="frame" x="0.0" y="494.66666666666663" width="361" height="31"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Card Only" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GZs-fw-UVI" userLabel="Card Only">
                                                                 <rect key="frame" x="0.0" y="0.0" width="312" height="31"/>
@@ -720,7 +737,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="lQz-T7-LCg">
-                                                        <rect key="frame" x="0.0" y="494.66666666666663" width="361" height="32"/>
+                                                        <rect key="frame" x="0.0" y="541.66666666666663" width="361" height="32"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Customer ID" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pi4-md-Lm0">
                                                                 <rect key="frame" x="0.0" y="0.0" width="211" height="32"/>
@@ -739,7 +756,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="DsA-0z-nCg">
-                                                        <rect key="frame" x="0.0" y="542.66666666666663" width="361" height="34"/>
+                                                        <rect key="frame" x="0.0" y="589.66666666666663" width="361" height="34"/>
                                                         <subviews>
                                                             <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="eE7-Om-WvW">
                                                                 <rect key="frame" x="0.0" y="0.0" width="317" height="34"/>
@@ -764,13 +781,13 @@
                                                         </subviews>
                                                     </stackView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="API Key" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J14-mn-E62">
-                                                        <rect key="frame" x="0.0" y="592.66666666666663" width="361" height="24"/>
+                                                        <rect key="frame" x="0.0" y="639.66666666666663" width="361" height="24"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                         <color key="textColor" name="Black Text Color"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="ucc-VN-sfr">
-                                                        <rect key="frame" x="0.0" y="632.66666666666663" width="361" height="34"/>
+                                                        <rect key="frame" x="0.0" y="679.66666666666663" width="361" height="34"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <textInputTraits key="textInputTraits"/>
                                                         <connections>
@@ -778,13 +795,13 @@
                                                         </connections>
                                                     </textField>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Client ID" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5p4-lS-mL2">
-                                                        <rect key="frame" x="0.0" y="682.66666666666663" width="361" height="24"/>
+                                                        <rect key="frame" x="0.0" y="729.66666666666663" width="361" height="24"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                         <color key="textColor" name="Black Text Color"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="Qvi-cl-UUP">
-                                                        <rect key="frame" x="0.0" y="722.66666666666663" width="361" height="34"/>
+                                                        <rect key="frame" x="0.0" y="769.66666666666663" width="361" height="34"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <textInputTraits key="textInputTraits"/>
                                                         <connections>
@@ -792,13 +809,13 @@
                                                         </connections>
                                                     </textField>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Amount" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5BH-xo-rjD">
-                                                        <rect key="frame" x="0.0" y="772.66666666666663" width="361" height="24"/>
+                                                        <rect key="frame" x="0.0" y="819.66666666666663" width="361" height="24"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                         <color key="textColor" name="Black Text Color"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="Ofq-7n-F5l">
-                                                        <rect key="frame" x="0.0" y="812.66666666666663" width="361" height="34"/>
+                                                        <rect key="frame" x="0.0" y="859.66666666666663" width="361" height="34"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <textInputTraits key="textInputTraits" keyboardType="decimalPad"/>
                                                         <connections>
@@ -806,13 +823,13 @@
                                                         </connections>
                                                     </textField>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Currency" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ap9-GE-PVt">
-                                                        <rect key="frame" x="0.0" y="862.66666666666663" width="361" height="24"/>
+                                                        <rect key="frame" x="0.0" y="909.66666666666663" width="361" height="24"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                         <color key="textColor" name="Black Text Color"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="XwV-xj-OFr">
-                                                        <rect key="frame" x="0.0" y="902.66666666666663" width="361" height="34"/>
+                                                        <rect key="frame" x="0.0" y="949.66666666666674" width="361" height="34"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <textInputTraits key="textInputTraits" autocapitalizationType="allCharacters"/>
                                                         <connections>
@@ -820,13 +837,13 @@
                                                         </connections>
                                                     </textField>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Country Code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cTx-Ag-RWK">
-                                                        <rect key="frame" x="0.0" y="952.66666666666674" width="361" height="24"/>
+                                                        <rect key="frame" x="0.0" y="999.66666666666674" width="361" height="24"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                         <color key="textColor" name="Black Text Color"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="Qdt-5n-Aof">
-                                                        <rect key="frame" x="0.0" y="992.66666666666674" width="361" height="34"/>
+                                                        <rect key="frame" x="0.0" y="1039.6666666666667" width="361" height="34"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <textInputTraits key="textInputTraits" autocapitalizationType="allCharacters"/>
                                                         <connections>
@@ -834,13 +851,13 @@
                                                         </connections>
                                                     </textField>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Return URL" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0po-GZ-hyq">
-                                                        <rect key="frame" x="0.0" y="1042.6666666666667" width="361" height="24"/>
+                                                        <rect key="frame" x="0.0" y="1089.6666666666667" width="361" height="24"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                         <color key="textColor" name="Black Text Color"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="KSE-Ui-RbN">
-                                                        <rect key="frame" x="0.0" y="1082.6666666666667" width="361" height="34"/>
+                                                        <rect key="frame" x="0.0" y="1129.6666666666667" width="361" height="34"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <textInputTraits key="textInputTraits"/>
                                                         <connections>
@@ -848,13 +865,13 @@
                                                         </connections>
                                                     </textField>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="WeChat Region:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iou-6j-t8u">
-                                                        <rect key="frame" x="0.0" y="1132.6666666666667" width="361" height="24"/>
+                                                        <rect key="frame" x="0.0" y="1179.6666666666667" width="361" height="24"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                         <color key="textColor" name="Black Text Color"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="App Version:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JTK-Dh-PCi">
-                                                        <rect key="frame" x="0.0" y="1172.6666666666667" width="361" height="24"/>
+                                                        <rect key="frame" x="0.0" y="1219.6666666666667" width="361" height="24"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                         <color key="textColor" name="Black Text Color"/>
                                                         <nil key="highlightedColor"/>
@@ -912,6 +929,7 @@
                         <outlet property="cvcSwitch" destination="wjD-bf-hn5" id="tdJ-dy-5gO"/>
                         <outlet property="modeButton" destination="Bgd-ni-rbG" id="9YE-6Q-HI8"/>
                         <outlet property="nextTriggerByBtn" destination="4fM-7O-jA1" id="QAH-bf-L71"/>
+                        <outlet property="redirectPayOnlySwitch" destination="WuA-yK-FcQ" id="T5Q-G8-2aW"/>
                         <outlet property="regionLabel" destination="iou-6j-t8u" id="Uq8-qd-c7A"/>
                         <outlet property="returnURLTextField" destination="KSE-Ui-RbN" id="yO1-ik-1ai"/>
                         <outlet property="scrollView" destination="lyV-gZ-kEV" id="Y8E-Uc-g8J"/>
@@ -941,6 +959,7 @@
                         <outletCollection property="titleLabels" destination="4O4-Bs-d1x" id="3MB-Mf-Jkc"/>
                         <outletCollection property="titleLabels" destination="aGh-WX-bDl" id="QHl-fR-u3I"/>
                         <outletCollection property="titleLabels" destination="GZs-fw-UVI" id="Bbn-aQ-YWj"/>
+                        <outletCollection property="titleLabels" destination="dFW-5I-euS" id="Alc-nZ-K3G"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="6DU-lc-9l6" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -985,7 +1004,7 @@
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="separatorColor">
-            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.28999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.28999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -33,7 +33,7 @@ EXTERNAL SOURCES:
     :path: "./"
 
 SPEC CHECKSUMS:
-  Airwallex: fe172d849441683852d6be50f04f3cf90fa6dbac
+  Airwallex: 17e50bc00b9a494ff67f6a191e5e2661fab6c5b9
   OCMock: 9491e4bec59e0b267d52a9184ff5605995e74be8
   WechatOpenSDK: 2f0ae448c7525cb5c27db5f7aa0f568de0988fa4
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ self.provider = provider;
 [provider confirmPaymentIntentWithCard:"The AWXCard object collected by your custom UI" billing:"The AWXPlaceDetails object collected by your custom UI" saveCard:"Whether you want the card to be saved as payment consent for future payments"];
 
 // Confirm intent with a payment consent object (AWXPaymentConsent)
-[provider confirmPaymentIntentWith:paymentConsent];
+[provider confirmPaymentIntentWithPaymentConsent:paymentConsent];
 
 // Confirm intent with a valid payment consent ID only when the saved card is **network token**
 [provider confirmPaymentIntentWithPaymentConsentId:@"cst_xxxxxxxxxx"];
@@ -238,7 +238,7 @@ self.provider = provider;
 // Initiate the apple pay flow
  [provider startPayment];
 // Confirm intent with a valid payment method name that supports redirect pay
-// [provider confirmPaymentIntentWith:@"payment method name"];
+// [provider confirmPaymentIntentWithPaymentMethodName:@"payment method name"];
 
 ``` 
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The Airwallex iOS SDK is a framework for integrating easy, fast and secure payme
 <img src="https://github.com/user-attachments/assets/0645ba1a-8cf1-4811-ba6f-c0b0f9589b98" width="200" hspace="10">
 <img src="https://github.com/user-attachments/assets/121f98d8-9944-4254-80b6-9f39d945c4c8" width="200" hspace="10">
 <img src="https://github.com/user-attachments/assets/9812c275-cb88-4835-a5e4-77bfa3b05319" width="200" hspace="10">
+</p>
 
 Get started with our integration guide and example project.
 
@@ -196,7 +197,7 @@ self.provider = provider;
 [provider confirmPaymentIntentWithCard:"The AWXCard object collected by your custom UI" billing:"The AWXPlaceDetails object collected by your custom UI" saveCard:"Whether you want the card to be saved as payment consent for future payments"];
 
 // Confirm intent with a payment consent object (AWXPaymentConsent)
-[provider confirmPaymentIntentWithPaymentConsent:paymentConsent];
+[provider confirmPaymentIntentWith:paymentConsent];
 
 // Confirm intent with a valid payment consent ID only when the saved card is **network token**
 [provider confirmPaymentIntentWithPaymentConsentId:@"cst_xxxxxxxxxx"];
@@ -223,18 +224,21 @@ If the payment consent is created during payment process, you can implement this
 }
 ```
 
-#### Launch payment with Apple Pay provider
+#### Launch payment with Apple Pay provider or Redirect provider
 
 You still need all the other steps in [Basic Integration](#basic-integration) section to set up configurations, intent and session, except the step **Present one-off payment or recurring flow** is replaced by:
 
 ```objective-c
 AWXApplePayProvider *provider = [[AWXApplePayProvider alloc] initWithDelegate:"The target to handle AWXProviderDelegate protocol" session:"The one off session created with apple pay options"];
+// AWXRedirectActionProvider *provider = [[AWXRedirectActionProvider alloc] initWithDelegate:"The target to handle AWXProviderDelegate protocol" session:"The one off session created"];
 
 // After initialization, you will need to store the provider in your view controller or class that is tied to your view's lifecycle
 self.provider = provider;
 
 // Initiate the apple pay flow
  [provider startPayment];
+// Confirm intent with a valid payment method name that supports redirect pay
+// [provider confirmPaymentIntentWith:@"payment method name"];
 
 ``` 
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -10,10 +10,11 @@
 Airwallex iOS SDK是一个框架，通过它可以在您的应用程序中轻松，快速和安全地完成付款。它提供了简单的功能，可以将敏感的信用卡数据直接发送到Airwallex，还提供了功能详细的界面，用于收集用户付款明细。
 
 <p align="center">
-<img src="./Screenshots/shipping.png" width="200" alt="AWXShippingViewController" hspace="10">
-<img src="./Screenshots/card.png" width="200" alt="AWXCardViewController" hspace="10">
-<img src="./Screenshots/payment method list.png" width="200" alt="AWXPaymentMethodListViewController" hspace="10">
-<img src="./Screenshots/payment.png" width="200" alt="AWXPaymentViewController" hspace="10">
+<img src="https://github.com/user-attachments/assets/e1c3f540-6cbb-4711-b392-24bbbdb7b779" width="200" hspace="10">
+<img src="https://github.com/user-attachments/assets/9ed00d30-fd45-4882-b6d0-e2171c64e0fb" width="200" hspace="10">
+<img src="https://github.com/user-attachments/assets/0645ba1a-8cf1-4811-ba6f-c0b0f9589b98" width="200" hspace="10">
+<img src="https://github.com/user-attachments/assets/121f98d8-9944-4254-80b6-9f39d945c4c8" width="200" hspace="10">
+<img src="https://github.com/user-attachments/assets/9812c275-cb88-4835-a5e4-77bfa3b05319" width="200" hspace="10">
 </p>
 
 开始使用我们的集成指南和示例项目。
@@ -36,7 +37,7 @@ Airwallex iOS SDK是一个框架，通过它可以在您的应用程序中轻松
 <!--te-->
 
 ## 要求
-Airwallex iOS SDK 支持 iOS 11.0 及以上版本。
+Airwallex iOS SDK 支持 iOS 13.0 及以上版本。并且需要 XCode 15.4 及以上版本编译运行，如果是老版本Xcode请参照之前发布的版本 [5.4.3](https://github.com/airwallex/airwallex-payment-ios/releases/tag/5.4.3)。
 
 ## 集成
 
@@ -193,7 +194,7 @@ self.provider = provider;
 [provider confirmPaymentIntentWithCard:"The AWXCard object collected by your custom UI" billing:"The AWXPlaceDetails object collected by your custom UI" saveCard:"Whether you want the card to be saved as payment consent for future payments"];
 
 // Confirm intent with a payment consent object (AWXPaymentConsent)
-[provider confirmPaymentIntentWithPaymentConsent:paymentConsent];
+[provider confirmPaymentIntentWith:paymentConsent];
 
 // Confirm intent with a valid payment consent ID only when the saved card is **network token**
 [provider confirmPaymentIntentWithPaymentConsentId:@"cst_xxxxxxxxxx"];
@@ -220,18 +221,21 @@ self.provider = provider;
 }
 ```
 
-#### 用Apple Pay provider来发起支付
+#### 用Apple Pay provider或Redirect provider来发起支付
 
 你仍然需要按照[基础集成](#基础集成)中的步骤来设置配置、intent和session, 除了**显示付款流程**的步骤由以下步骤代替:
 
 ```objective-c
 AWXApplePayProvider *provider = [[AWXApplePayProvider alloc] initWithDelegate:"The target to handle AWXProviderDelegate protocol" session:"The one off session created with apple pay options"];
+// AWXRedirectActionProvider *provider = [[AWXRedirectActionProvider alloc] initWithDelegate:"The target to handle AWXProviderDelegate protocol" session:"The one off session created"];
 
 // After initialization, you will need to store the provider in your view controller or class that is tied to your view's lifecycle
 self.provider = provider;
 
 // Initiate the apple pay flow
  [provider startPayment];
+// Confirm intent with a valid payment method name that supports redirect pay
+// [provider confirmPaymentIntentWith:@"payment method name"];
 
 ``` 
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -194,7 +194,7 @@ self.provider = provider;
 [provider confirmPaymentIntentWithCard:"The AWXCard object collected by your custom UI" billing:"The AWXPlaceDetails object collected by your custom UI" saveCard:"Whether you want the card to be saved as payment consent for future payments"];
 
 // Confirm intent with a payment consent object (AWXPaymentConsent)
-[provider confirmPaymentIntentWith:paymentConsent];
+[provider confirmPaymentIntentWithPaymentConsent:paymentConsent];
 
 // Confirm intent with a valid payment consent ID only when the saved card is **network token**
 [provider confirmPaymentIntentWithPaymentConsentId:@"cst_xxxxxxxxxx"];
@@ -235,7 +235,7 @@ self.provider = provider;
 // Initiate the apple pay flow
  [provider startPayment];
 // Confirm intent with a valid payment method name that supports redirect pay
-// [provider confirmPaymentIntentWith:@"payment method name"];
+// [provider confirmPaymentIntentWithPaymentMethodName:@"payment method name"];
 
 ``` 
 


### PR DESCRIPTION
This provides low-level API `confirmPaymentIntentWithPaymentMethodName:additionalInfo:flow:` that can confirm a payment intent with LPM redirect payment.