### PR TITLE
APAM-142 make save card switcher configurable

### DIFF
--- a/Airwallex/Card/AWXCardViewController.m
+++ b/Airwallex/Card/AWXCardViewController.m
@@ -169,7 +169,7 @@ typedef enum {
     [_expiresField.widthAnchor constraintEqualToAnchor:_cvcField.widthAnchor multiplier:1.7].active = YES;
 
     if (self.viewModel.isCardSavingEnabled) {
-        self.saveCard = self.viewModel.isCardSavingEnabledByDefault;
+        self.saveCard = self.viewModel.autoSaveCardForFuturePayments;
         [stackView addArrangedSubview:[self switchOfType:SaveCardSwitch isOn:self.saveCard]];
     }
 

--- a/Airwallex/Card/AWXCardViewController.m
+++ b/Airwallex/Card/AWXCardViewController.m
@@ -169,7 +169,8 @@ typedef enum {
     [_expiresField.widthAnchor constraintEqualToAnchor:_cvcField.widthAnchor multiplier:1.7].active = YES;
 
     if (self.viewModel.isCardSavingEnabled) {
-        [stackView addArrangedSubview:[self switchOfType:SaveCardSwitch]];
+        self.saveCard = self.viewModel.isCardSavingEnabledByDefault;
+        [stackView addArrangedSubview:[self switchOfType:SaveCardSwitch isOn:self.saveCard]];
     }
 
     if (self.viewModel.isBillingInformationRequired) {
@@ -200,12 +201,10 @@ typedef enum {
         }
     }
     [self setBillingInputHidden:self.viewModel.isReusingShippingAsBillingInformation];
-    _addressSwitch.on = self.viewModel.isReusingShippingAsBillingInformation;
-    self.saveCard = false;
     self.container = stackView;
 }
 
-- (UIStackView *)switchOfType:(SwitchType)type {
+- (UIStackView *)switchOfType:(SwitchType)type isOn:(BOOL)isOn {
     UIStackView *container = [UIStackView new];
     container.axis = UILayoutConstraintAxisHorizontal;
     container.alignment = UIStackViewAlignmentFill;
@@ -231,6 +230,7 @@ typedef enum {
     titleLabel.font = [UIFont subhead1Font];
     [container addArrangedSubview:titleLabel];
     [container addArrangedSubview:switchButton];
+    switchButton.on = isOn;
     return container;
 }
 
@@ -248,7 +248,7 @@ typedef enum {
     billingLabel.font = [UIFont subhead2Font];
     [stackView addArrangedSubview:billingLabel];
 
-    [stackView addArrangedSubview:[self switchOfType:AddressSwitch]];
+    [stackView addArrangedSubview:[self switchOfType:AddressSwitch isOn:self.viewModel.isReusingShippingAsBillingInformation]];
 
     _firstNameField = [AWXFloatingLabelTextField new];
     _firstNameField.fieldType = AWXTextFieldTypeFirstName;

--- a/Airwallex/Card/AWXCardViewModel.h
+++ b/Airwallex/Card/AWXCardViewModel.h
@@ -25,6 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) BOOL isReusingShippingAsBillingInformation;
 @property (nonatomic, readonly) BOOL isBillingInformationRequired;
 @property (nonatomic, readonly) BOOL isCardSavingEnabled;
+@property (nonatomic, readonly) BOOL isCardSavingEnabledByDefault;
 @property (nonatomic, strong, readonly) AWXPlaceDetails *initialBilling;
 @property (nonatomic, strong, nullable) AWXCountry *selectedCountry;
 @property (nonatomic) AWXBrandType currentBrand;

--- a/Airwallex/Card/AWXCardViewModel.h
+++ b/Airwallex/Card/AWXCardViewModel.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) BOOL isReusingShippingAsBillingInformation;
 @property (nonatomic, readonly) BOOL isBillingInformationRequired;
 @property (nonatomic, readonly) BOOL isCardSavingEnabled;
-@property (nonatomic, readonly) BOOL isCardSavingEnabledByDefault;
+@property (nonatomic, readonly) BOOL autoSaveCardForFuturePayments;
 @property (nonatomic, strong, readonly) AWXPlaceDetails *initialBilling;
 @property (nonatomic, strong, nullable) AWXCountry *selectedCountry;
 @property (nonatomic) AWXBrandType currentBrand;

--- a/Airwallex/Card/AWXCardViewModel.m
+++ b/Airwallex/Card/AWXCardViewModel.m
@@ -61,12 +61,12 @@
     return [self.session isKindOfClass:[AWXOneOffSession class]] && self.session.customerId;
 }
 
-- (BOOL)isCardSavingEnabledByDefault {
+- (BOOL)autoSaveCardForFuturePayments {
     if (!self.isCardSavingEnabled) {
         return NO;
     }
 
-    return [(AWXOneOffSession *)self.session isCardSavingEnabledByDefault];
+    return [(AWXOneOffSession *)self.session autoSaveCardForFuturePayments];
 }
 
 - (AWXPlaceDetails *)initialBilling {

--- a/Airwallex/Card/AWXCardViewModel.m
+++ b/Airwallex/Card/AWXCardViewModel.m
@@ -61,6 +61,14 @@
     return [self.session isKindOfClass:[AWXOneOffSession class]] && self.session.customerId;
 }
 
+- (BOOL)isCardSavingEnabledByDefault {
+    if (!self.isCardSavingEnabled) {
+        return NO;
+    }
+
+    return [(AWXOneOffSession *)self.session isCardSavingEnabledByDefault];
+}
+
 - (AWXPlaceDetails *)initialBilling {
     return self.session.billing;
 }

--- a/Airwallex/CardTests/AWXCardViewModelTests.m
+++ b/Airwallex/CardTests/AWXCardViewModelTests.m
@@ -64,15 +64,15 @@
     AWXCardViewModel *viewModel = [[AWXCardViewModel alloc] initWithSession:session supportedCardSchemes:NULL launchDirectly:NO];
     XCTAssertTrue(viewModel.isCardSavingEnabled);
 
-    XCTAssertTrue(viewModel.isCardSavingEnabledByDefault);
-    session.isCardSavingEnabledByDefault = false;
-    XCTAssertFalse(viewModel.isCardSavingEnabledByDefault);
+    XCTAssertTrue(viewModel.autoSaveCardForFuturePayments);
+    session.autoSaveCardForFuturePayments = false;
+    XCTAssertFalse(viewModel.autoSaveCardForFuturePayments);
 }
 
 - (void)testIsCardSavingEnabledWhenRecurringSession {
     AWXCardViewModel *viewModel = [self mockRecurringViewModel];
     XCTAssertFalse(viewModel.isCardSavingEnabled);
-    XCTAssertFalse(viewModel.isCardSavingEnabledByDefault);
+    XCTAssertFalse(viewModel.autoSaveCardForFuturePayments);
 }
 
 - (void)testInitialBilling {

--- a/Airwallex/CardTests/AWXCardViewModelTests.m
+++ b/Airwallex/CardTests/AWXCardViewModelTests.m
@@ -63,11 +63,16 @@
     session.paymentIntent = intent;
     AWXCardViewModel *viewModel = [[AWXCardViewModel alloc] initWithSession:session supportedCardSchemes:NULL launchDirectly:NO];
     XCTAssertTrue(viewModel.isCardSavingEnabled);
+
+    XCTAssertFalse(viewModel.isCardSavingEnabledByDefault);
+    session.isCardSavingEnabledByDefault = true;
+    XCTAssertTrue(viewModel.isCardSavingEnabledByDefault);
 }
 
 - (void)testIsCardSavingEnabledWhenRecurringSession {
     AWXCardViewModel *viewModel = [self mockRecurringViewModel];
     XCTAssertFalse(viewModel.isCardSavingEnabled);
+    XCTAssertFalse(viewModel.isCardSavingEnabledByDefault);
 }
 
 - (void)testInitialBilling {

--- a/Airwallex/CardTests/AWXCardViewModelTests.m
+++ b/Airwallex/CardTests/AWXCardViewModelTests.m
@@ -64,9 +64,9 @@
     AWXCardViewModel *viewModel = [[AWXCardViewModel alloc] initWithSession:session supportedCardSchemes:NULL launchDirectly:NO];
     XCTAssertTrue(viewModel.isCardSavingEnabled);
 
-    XCTAssertFalse(viewModel.isCardSavingEnabledByDefault);
-    session.isCardSavingEnabledByDefault = true;
     XCTAssertTrue(viewModel.isCardSavingEnabledByDefault);
+    session.isCardSavingEnabledByDefault = false;
+    XCTAssertFalse(viewModel.isCardSavingEnabledByDefault);
 }
 
 - (void)testIsCardSavingEnabledWhenRecurringSession {

--- a/Airwallex/Core/Sources/AWXSession.h
+++ b/Airwallex/Core/Sources/AWXSession.h
@@ -126,7 +126,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic) BOOL hidePaymentConsents;
 
-/// Indicates whether card saving is enabled by default for card payments. Defaults to NO.
+/// Indicates whether card saving is enabled by default for card payments. Defaults to YES.
 @property (nonatomic, assign) BOOL isCardSavingEnabledByDefault;
 
 @end

--- a/Airwallex/Core/Sources/AWXSession.h
+++ b/Airwallex/Core/Sources/AWXSession.h
@@ -126,6 +126,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic) BOOL hidePaymentConsents;
 
+/// Indicates whether card saving is enabled by default for card payments. Defaults to NO.
+@property (nonatomic, assign) BOOL isCardSavingEnabledByDefault;
+
 @end
 
 /**

--- a/Airwallex/Core/Sources/AWXSession.h
+++ b/Airwallex/Core/Sources/AWXSession.h
@@ -126,8 +126,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic) BOOL hidePaymentConsents;
 
-/// Indicates whether card saving is enabled by default for card payments. Defaults to YES.
-@property (nonatomic, assign) BOOL isCardSavingEnabledByDefault;
+/// Indicates whether card saving is enabled by default. Defaults to YES.
+@property (nonatomic, assign) BOOL autoSaveCardForFuturePayments;
 
 @end
 

--- a/Airwallex/Core/Sources/AWXSession.m
+++ b/Airwallex/Core/Sources/AWXSession.m
@@ -155,6 +155,7 @@ static NSString *const recurring = @"recurring";
 - (instancetype)init {
     if (self = [super init]) {
         self.autoCapture = YES;
+        self.isCardSavingEnabledByDefault = YES;
     }
 
     return self;

--- a/Airwallex/Core/Sources/AWXSession.m
+++ b/Airwallex/Core/Sources/AWXSession.m
@@ -155,9 +155,8 @@ static NSString *const recurring = @"recurring";
 - (instancetype)init {
     if (self = [super init]) {
         self.autoCapture = YES;
-        self.isCardSavingEnabledByDefault = YES;
+        self.autoSaveCardForFuturePayments = YES;
     }
-
     return self;
 }
 

--- a/Examples/Examples/Cart/CartViewController.swift
+++ b/Examples/Examples/Cart/CartViewController.swift
@@ -195,8 +195,8 @@ class CartViewController: UIViewController {
                         // Step 4: Present payment flow
                         self.presentPaymentFlow(session: session)
                         
-                        // For one-off session, you can choose to enable card saving by default
-                        (session as? AWXOneOffSession)?.isCardSavingEnabledByDefault = true
+                        // For one-off session, card saving is enabled by default
+                        (session as? AWXOneOffSession)?.isCardSavingEnabledByDefault = false
                     case .failure(let error):
                         self.showAlert(error.localizedDescription, withTitle: nil)
                     }

--- a/Examples/Examples/Cart/CartViewController.swift
+++ b/Examples/Examples/Cart/CartViewController.swift
@@ -194,6 +194,9 @@ class CartViewController: UIViewController {
                         
                         // Step 4: Present payment flow
                         self.presentPaymentFlow(session: session)
+                        
+                        // For one-off session, you can choose to enable card saving by default
+                        (session as? AWXOneOffSession)?.isCardSavingEnabledByDefault = true
                     case .failure(let error):
                         self.showAlert(error.localizedDescription, withTitle: nil)
                     }

--- a/Examples/Examples/Cart/CartViewController.swift
+++ b/Examples/Examples/Cart/CartViewController.swift
@@ -196,7 +196,7 @@ class CartViewController: UIViewController {
                         self.presentPaymentFlow(session: session)
                         
                         // For one-off session, card saving is enabled by default
-                        (session as? AWXOneOffSession)?.isCardSavingEnabledByDefault = false
+//                        (session as? AWXOneOffSession)?.autoSaveCardForFuturePayments = false
                     case .failure(let error):
                         self.showAlert(error.localizedDescription, withTitle: nil)
                     }


### PR DESCRIPTION
default value of card switcher can be configured by this property in `AWXOneOffSession `
```
/// Indicates whether card saving is enabled by default for card payments. Defaults to NO.
@property (nonatomic, assign) BOOL isCardSavingEnabledByDefault;
```