### PR TITLE
fix: APAM-196 handling clear button action

### DIFF
--- a/Airwallex/AirwallexPaymentSheet/Sources/PaymentSheet/View/InputFields/InfoCollectorTextFieldViewModel.swift
+++ b/Airwallex/AirwallexPaymentSheet/Sources/PaymentSheet/View/InputFields/InfoCollectorTextFieldViewModel.swift
@@ -153,6 +153,11 @@ extension InfoCollectorTextFieldViewModel: UITextFieldDelegate {
         editingEventObserver?.handleEditingEvent(event: .editingDidBegin, for: textField)
     }
     
+    func textFieldShouldClear(_ textField: UITextField) -> Bool {
+        let range = NSRange(location: 0, length: textField.text?.count ?? 0)
+        return self.textField(textField, shouldChangeCharactersIn: range, replacementString: "")
+    }
+    
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         guard let range = Range(range, in: textField.text ?? "") else {
             return false


### PR DESCRIPTION
Clear button tap action is not handled correctly. When user click clear button, input validation status and data on InfoCollectorTextFieldViewModel is not updated because the text change will not trigger callback of `textField(_:shouldChangeCharactersIn:replacementString:)`