### PR TITLE
chore: APAM-356 Update logging field names to camelCase

### DIFF
--- a/Airwallex/AirwallexCore/Sources/ApplePay/AWXApplePayProvider.m
+++ b/Airwallex/AirwallexCore/Sources/ApplePay/AWXApplePayProvider.m
@@ -250,7 +250,7 @@ typedef enum {
         strongSelf.paymentState = NotStarted;
         [[AWXAnalyticsLogger shared] logPageViewWithName:@"apple_pay_sheet"
                                           additionalInfo:@{
-                                              @"supported_networks": session.applePayOptions.supportedNetworks ?: @[]
+                                              @"supportedNetworks": session.applePayOptions.supportedNetworks ?: @[]
                                           }];
         [self log:@"Show apple pay"];
     }];

--- a/Airwallex/AirwallexCore/Sources/Logging/AWXAnalyticsLogger.m
+++ b/Airwallex/AirwallexCore/Sources/Logging/AWXAnalyticsLogger.m
@@ -171,10 +171,10 @@
 
 - (void)addInfoFromPaymentSession:(AWXSession *)session {
     if (session.paymentIntentId) {
-        self[@"payment_intent_id"] = session.paymentIntentId;
+        self[@"paymentIntentId"] = session.paymentIntentId;
     }
     if (session.transactionMode) {
-        self[@"transaction_mode"] = session.transactionMode;
+        self[@"transactionMode"] = session.transactionMode;
     }
 }
 

--- a/Airwallex/AirwallexCoreTests/ApplePayTests/AWXApplePayProviderTest.m
+++ b/Airwallex/AirwallexCoreTests/ApplePayTests/AWXApplePayProviderTest.m
@@ -259,7 +259,7 @@
 
     OCMVerify(times(1), [_logger logPageViewWithName:@"apple_pay_sheet"
                                       additionalInfo:@{
-                                          @"supported_networks": session.applePayOptions.supportedNetworks ?: @[]
+                                          @"supportedNetworks": session.applePayOptions.supportedNetworks ?: @[]
                                       }]);
 
     OCMVerify(times(1), [providerSpy confirmPaymentIntentWithPaymentMethod:[OCMArg checkWithBlock:^BOOL(id obj) {
@@ -312,7 +312,7 @@
 
     OCMVerify(times(1), [_logger logPageViewWithName:@"apple_pay_sheet"
                                       additionalInfo:@{
-                                          @"supported_networks": session.applePayOptions.supportedNetworks ?: @[]
+                                          @"supportedNetworks": session.applePayOptions.supportedNetworks ?: @[]
                                       }]);
 
     OCMVerify(times(1), [providerSpy createPaymentConsentAndConfirmIntentWithPaymentMethod:[OCMArg checkWithBlock:^BOOL(id obj) {

--- a/Airwallex/AirwallexPayment/Sources/Events.swift
+++ b/Airwallex/AirwallexPayment/Sources/Events.swift
@@ -16,15 +16,15 @@ import AirwallexCore
     
     @_spi(AWX) public enum Fields: String {
         case subtype = "subtype"
-        case intentId = "intent_id"
+        case intentId = "intentId"
         case paymentMethod = "paymentMethod"
-        case consentId = "consent_id"
+        case consentId = "consentId"
         case supportedSchemes = "supportedSchemes"
         case bankName = "bankName"
         case message = "message"
         case value = "value"
         case eventType = "eventType"
-        case supportedNetworks = "supported_networks"
+        case supportedNetworks = "supportedNetworks"
     }
     
     @_spi(AWX) public enum PageView: String {


### PR DESCRIPTION
## Summary
Update analytics logging field names from snake_case to camelCase for consistency with Swift naming conventions.

## Changes Made
### Analytics Field Definitions
- **Events.swift**: Updated enum field values to camelCase
  - `intent_id` → `intentId`
  - `consent_id` → `consentId` 
  - `supported_networks` → `supportedNetworks`

### Analytics Logger Implementation
- **AWXAnalyticsLogger.m**: Updated session info field names
  - `payment_intent_id` → `paymentIntentId`
  - `transaction_mode` → `transactionMode`

### Apple Pay Provider
- **AWXApplePayProvider.m**: Updated analytics field name
  - `supported_networks` → `supportedNetworks`

### Test Files
- **AWXApplePayProviderTest.m**: Updated test expectations to match new field names

## Technical Details
- ✅ **Analytics fields** now use camelCase (Swift standard)
- ✅ **API request/response fields** remain snake_case (backend compatibility)
- ✅ **Test coverage** updated to match new conventions
- ✅ **Backward compatibility** maintained for API contracts

## Benefits
- **Consistency** with Swift naming conventions
- **Better IDE support** and autocomplete
- **Improved code readability** across the codebase
- **Future maintenance** alignment with modern standards

🤖 Generated with [Claude Code](https://claude.ai/code)