### PR TITLE
[APAM-625] Fix CocoaPods deployment action error propagation

### DIFF
--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -14,6 +14,11 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # 3.6.0
         
-      - uses: michaelhenry/deploy-to-cocoapods-github-action@745686ab065f90596e0d5cfcf97bb2416d94262e #1.0.10
+      - name: Deploy to CocoaPods
+        run: |
+          set -eo pipefail
+          gem install cocoapods
+          pod lib lint --allow-warnings
+          pod trunk push --allow-warnings
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}

--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -2,9 +2,8 @@ name: Push release to Cocoapods
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - '*'
+  release:
+    types: [published]
 
 jobs:
   cocoapods:


### PR DESCRIPTION
## Summary
- Replace third-party `deploy-to-cocoapods-github-action` with direct shell commands
- The action didn't propagate failures (e.g., invalid authentication token errors) because `shelljs.exec()` doesn't exit on non-zero codes by default
- Using `set -eo pipefail` ensures the job fails immediately on any error
- Change trigger from tag push to `release: published` event

## Test plan
- [ ] Publish a GitHub release
- [ ] Verify workflow triggers and deploys to CocoaPods
- [ ] Verify job fails correctly if `COCOAPODS_TRUNK_TOKEN` is invalid

🤖 Generated with [Claude Code](https://claude.ai/code)