### PR TITLE
[APAM-628] Status polling for embedded element in demo app

### DIFF
--- a/Examples/Examples/Controllers/EmbeddedIntegrationDemoViewController.swift
+++ b/Examples/Examples/Controllers/EmbeddedIntegrationDemoViewController.swift
@@ -175,11 +175,15 @@ extension EmbeddedIntegrationDemoViewController: AWXPaymentElementDelegate {
                 action: action
             )
         case .inProgress:
-            print("Payment in progress for \(paymentMethod), you should check payment status from time to time from backend and show result to the payer")
-            showAlert(
-                message: "Payment in progress",
-                action: action
-            )
+            if let intentId = session?.paymentIntentId() {
+                Task {
+                    startLoading()
+                    await startPollingForPaymentIntent(intentId) { [weak self] in
+                        self?.navigationController?.popViewController(animated: true)
+                    }
+                    stopLoading()
+                }
+            }
         case .failure:
             showAlert(
                 message: error?.localizedDescription ?? "There was an error while processing your payment. Please try again.",

--- a/Examples/Examples/Controllers/IntegrationDemoListViewController.swift
+++ b/Examples/Examples/Controllers/IntegrationDemoListViewController.swift
@@ -340,7 +340,11 @@ extension IntegrationDemoListViewController: AWXPaymentResultDelegate {
             print("Payment in progress, you should check payment status from time to time from backend and show result to the payer")
             // Extract intent ID and start polling using paymentIntentId()
             if let intentId = session?.paymentIntentId() {
-                startPollingForPaymentIntent(intentId)
+                Task {
+                    startLoading()
+                    await startPollingForPaymentIntent(intentId)
+                    stopLoading()
+                }
             }
         case .failure:
             showAlert(message: error?.localizedDescription ?? "There was an error while processing your payment. Please try again.", title: "Payment failed")
@@ -358,7 +362,7 @@ extension IntegrationDemoListViewController: AWXPaymentResultDelegate {
 
 // MARK: - Payment Status Polling
 extension IntegrationDemoListViewController {
-    func startPollingForPaymentIntent(_ intentId: String) {
+    func startPollingForPaymentIntent(_ intentId: String, onComplete: (() -> Void)? = nil) async {
         paymentStatusPoller?.stop()
 
         let poller = PaymentStatusPoller(
@@ -367,42 +371,39 @@ extension IntegrationDemoListViewController {
         )
         paymentStatusPoller = poller
 
-        startLoading()
-
-        Task {
-            do {
-                let attempt = try await poller.getPaymentAttempt()
-                stopLoading()
+        do {
+            let attempt = try await poller.getPaymentAttempt()
+            showAlert(
+                message: attempt.description,
+                title: session?.paymentIntentId() ?? "",
+                action: onComplete
+            )
+        } catch let error as PaymentStatusPoller.PollingError {
+            switch error {
+            case .timeout(let lastAttempt):
                 showAlert(
-                    message: attempt.description,
-                    title: session?.paymentIntentId() ?? ""
+                    message: "Payment status \(lastAttempt?.status.rawValue ?? "unknown")",
+                    title: "Polling timeout",
+                    action: onComplete
                 )
-            } catch let error as PaymentStatusPoller.PollingError {
-                stopLoading()
-                switch error {
-                case .timeout(let lastAttempt):
-                    showAlert(
-                        message: "Payment status \(lastAttempt?.status.rawValue ?? "unknown")",
-                        title: "Polling timeout"
-                    )
-                case .apiError(let underlyingError):
-                    showAlert(
-                        message: "Error checking payment status: \(underlyingError.localizedDescription)",
-                        title: "Error"
-                    )
-                case .paymentAttemptNotFound:
-                    // Ignore payment attempt not found error
-                    // usually this is caused by LPM recurring transaction
-                    // which use legacy create/verify payemnt consent instead of confirm payment intent
-                    break
-                }
-            } catch {
-                stopLoading()
+            case .apiError(let underlyingError):
                 showAlert(
-                    message: "Error checking payment status: \(error.localizedDescription)",
-                    title: "Error"
+                    message: "Error checking payment status: \(underlyingError.localizedDescription)",
+                    title: "Error",
+                    action: onComplete
                 )
+            case .paymentAttemptNotFound:
+                // Ignore payment attempt not found error
+                // usually this is caused by LPM recurring transaction
+                // which use legacy create/verify payemnt consent instead of confirm payment intent
+                onComplete?()
             }
+        } catch {
+            showAlert(
+                message: "Error checking payment status: \(error.localizedDescription)",
+                title: "Error",
+                action: onComplete
+            )
         }
     }
 }


### PR DESCRIPTION
https://github.com/user-attachments/assets/a7f6c74f-623f-4be5-bc5f-ac518e876600

## Summary
- Convert `startPollingForPaymentIntent` from sync (internal `Task`) to `async`, moving loading state management to callers
- Add optional `onComplete` closure parameter passed to `showAlert` actions so callers can run custom logic after polling finishes
- Update `EmbeddedIntegrationDemoViewController` `inProgress` case to use actual polling instead of a static alert, popping the navigation stack on completion

## Test plan
- [ ] Verify polling works correctly in `IntegrationDemoListViewController` for in-progress payments
- [ ] Verify `EmbeddedIntegrationDemoViewController` polls and pops the navigation stack after the alert is dismissed
- [ ] Verify polling timeout and error cases still show appropriate alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)