### PR TITLE
[APAM-627] Propagate cancel status instead of failure when user cancels 3DS

### DIFF
--- a/Airwallex/Airwallex.xcodeproj/project.pbxproj
+++ b/Airwallex/Airwallex.xcodeproj/project.pbxproj
@@ -133,6 +133,7 @@
 		D81983492D6F120B008008A3 /* AirwallexPayment.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D81983412D6F120B008008A3 /* AirwallexPayment.framework */; };
 		D81983D62D6F12BD008008A3 /* AirwallexCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 085BD3C823CC62B4002E8F27 /* AirwallexCore.framework */; platformFilter = ios; };
 		D81983E82D6F1438008008A3 /* AirwallexRisk.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1803AC8D2C59DB4300BC9FBF /* AirwallexRisk.xcframework */; };
+		D81C742F2F7E1974000EDC74 /* AWX3DSServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D81C742E2F7E1974000EDC74 /* AWX3DSServiceTests.m */; };
 		D8269FB22DB7701300E179EB /* AWXApplePayProviderTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C5A37D527EAFD9F00CFC2EF /* AWXApplePayProviderTest.m */; };
 		D8269FB32DB7701300E179EB /* PKContactRequestTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CE9BA292806D923005B70C3 /* PKContactRequestTest.m */; };
 		D8269FB42DB7701300E179EB /* AWXPaymentIntentSummaryTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C5A37F527ED65C200CFC2EF /* AWXPaymentIntentSummaryTest.m */; };
@@ -146,11 +147,11 @@
 		D829FE142F0D11450056EE6E /* AWXPaymentElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = D829FE102F0D11450056EE6E /* AWXPaymentElement.swift */; };
 		D829FE162F0D11450056EE6E /* EmbeddedPaymentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D829FE122F0D11450056EE6E /* EmbeddedPaymentView.swift */; };
 		D8316DC22E6AF16D002A42BA /* SchemaFieldValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8316DC12E6AF16D002A42BA /* SchemaFieldValidator.swift */; };
-		D8344E052F5979BF0087BF54 /* PaymentUIContextProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8344E042F5979BF0087BF54 /* PaymentUIContextProviding.swift */; };
 		D834491E2F5844520087BF54 /* BottomSheetPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D834491D2F5844520087BF54 /* BottomSheetPresentationController.swift */; };
 		D83449202F58445D0087BF54 /* BottomSheetAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D834491F2F58445D0087BF54 /* BottomSheetAnimator.swift */; };
 		D83449222F58446D0087BF54 /* BottomSheetInteractiveDismissTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83449212F58446D0087BF54 /* BottomSheetInteractiveDismissTransition.swift */; };
 		D83449242F5844750087BF54 /* BottomSheetTransitioningDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83449232F5844750087BF54 /* BottomSheetTransitioningDelegate.swift */; };
+		D8344E052F5979BF0087BF54 /* PaymentUIContextProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8344E042F5979BF0087BF54 /* PaymentUIContextProviding.swift */; };
 		D83AD9C82EF544A600649996 /* CompoundItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83AD9C72EF544A600649996 /* CompoundItem.swift */; };
 		D84E94D52D68324600CDC04C /* WechatOpenSDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D84E94D42D68324600CDC04C /* WechatOpenSDK.xcframework */; };
 		D85041C82DA7957A0074BA7F /* AirwallexPaymentSheet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D850407B2DA795470074BA7F /* AirwallexPaymentSheet.framework */; };
@@ -243,8 +244,8 @@
 		D85042DA2DA7A46D0074BA7F /* AWXWidgets.h in Sources */ = {isa = PBXBuildFile; fileRef = 5775CEEA26E5DF4E00C6AFE3 /* AWXWidgets.h */; };
 		D85042DC2DA7A46D0074BA7F /* AWXFloatingCvcTextField.h in Sources */ = {isa = PBXBuildFile; fileRef = 1820C96E2C85A1C0006B18C4 /* AWXFloatingCvcTextField.h */; };
 		D85042DD2DA7A46D0074BA7F /* NSObject+Logging.h in Sources */ = {isa = PBXBuildFile; fileRef = C844DC7B2C3CE37F0099614C /* NSObject+Logging.h */; };
-		D87DC6C02F304E0C007CE434 /* PaymentReminderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87DC6BF2F304E0C007CE434 /* PaymentReminderCell.swift */; };
 		D86309D02F56E81800052460 /* BankListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86309CF2F56E81800052460 /* BankListViewController.swift */; };
+		D87DC6C02F304E0C007CE434 /* PaymentReminderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87DC6BF2F304E0C007CE434 /* PaymentReminderCell.swift */; };
 		D87FFFD62E70304F0008784D /* TermsOfUse.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87FFFD52E70304F0008784D /* TermsOfUse.swift */; };
 		D880456A2DA7B281008308C7 /* MockProviderDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8EC87D42D9E335D00D082EC /* MockProviderDelegate.swift */; };
 		D880456B2DA7B281008308C7 /* Bundle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8EC87D12D9E335D00D082EC /* Bundle+Extensions.swift */; };
@@ -620,15 +621,16 @@
 		D81983412D6F120B008008A3 /* AirwallexPayment.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AirwallexPayment.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D81983482D6F120B008008A3 /* AirwallexPaymentTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AirwallexPaymentTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D81983EA2D6F1C70008008A3 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		D81C742E2F7E1974000EDC74 /* AWX3DSServiceTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWX3DSServiceTests.m; sourceTree = "<group>"; };
 		D829FE092F0D11380056EE6E /* PaymentUIContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentUIContext.swift; sourceTree = "<group>"; };
 		D829FE102F0D11450056EE6E /* AWXPaymentElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWXPaymentElement.swift; sourceTree = "<group>"; };
 		D829FE122F0D11450056EE6E /* EmbeddedPaymentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddedPaymentView.swift; sourceTree = "<group>"; };
 		D8316DC12E6AF16D002A42BA /* SchemaFieldValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaFieldValidator.swift; sourceTree = "<group>"; };
-		D8344E042F5979BF0087BF54 /* PaymentUIContextProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentUIContextProviding.swift; sourceTree = "<group>"; };
 		D834491D2F5844520087BF54 /* BottomSheetPresentationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetPresentationController.swift; sourceTree = "<group>"; };
 		D834491F2F58445D0087BF54 /* BottomSheetAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetAnimator.swift; sourceTree = "<group>"; };
 		D83449212F58446D0087BF54 /* BottomSheetInteractiveDismissTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetInteractiveDismissTransition.swift; sourceTree = "<group>"; };
 		D83449232F5844750087BF54 /* BottomSheetTransitioningDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetTransitioningDelegate.swift; sourceTree = "<group>"; };
+		D8344E042F5979BF0087BF54 /* PaymentUIContextProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentUIContextProviding.swift; sourceTree = "<group>"; };
 		D8352B4D2DA640B10025BE9E /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		D83AD9C72EF544A600649996 /* CompoundItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompoundItem.swift; sourceTree = "<group>"; };
 		D84E94D42D68324600CDC04C /* WechatOpenSDK.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = WechatOpenSDK.xcframework; path = ../Frameworks/WechatOpenSDK.xcframework; sourceTree = "<group>"; };
@@ -642,8 +644,8 @@
 		D85041F62DA79D380074BA7F /* AWXWeChatPayActionProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AWXWeChatPayActionProvider.h; sourceTree = "<group>"; };
 		D85041F72DA79D380074BA7F /* AWXWeChatPayActionProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWXWeChatPayActionProvider.m; sourceTree = "<group>"; };
 		D85041FA2DA79D490074BA7F /* AirwallexWeChatPay.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AirwallexWeChatPay.h; sourceTree = "<group>"; };
-		D87DC6BF2F304E0C007CE434 /* PaymentReminderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentReminderCell.swift; sourceTree = "<group>"; };
 		D86309CF2F56E81800052460 /* BankListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankListViewController.swift; sourceTree = "<group>"; };
+		D87DC6BF2F304E0C007CE434 /* PaymentReminderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentReminderCell.swift; sourceTree = "<group>"; };
 		D87FFFD52E70304F0008784D /* TermsOfUse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsOfUse.swift; sourceTree = "<group>"; };
 		D88E34B82DA7E93100183A49 /* Airwallex_Export.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Airwallex_Export.swift; sourceTree = "<group>"; };
 		D895DD7D2EBC42B600E29F08 /* PaymentIntentProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentIntentProvider.swift; sourceTree = "<group>"; };
@@ -793,7 +795,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		D85C1E362EC34C8500465FC8 /* Exceptions for "AirwallexPaymentTests" folder in "AirwallexPaymentSheetTests" target */ = {
+		D85C1E362EC34C8500465FC8 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				MockObjects/MockPaymentIntentProvider.swift,
@@ -803,29 +805,8 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		D8D371412E60566A005618D4 /* AirwallexPaymentTests */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				D85C1E362EC34C8500465FC8 /* Exceptions for "AirwallexPaymentTests" folder in "AirwallexPaymentSheetTests" target */,
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			path = AirwallexPaymentTests;
-			sourceTree = "<group>";
-		};
-		D8D371942E605670005618D4 /* AirwallexPaymentSheetTests */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			path = AirwallexPaymentSheetTests;
-			sourceTree = "<group>";
-		};
+		D8D371412E60566A005618D4 /* AirwallexPaymentTests */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (D85C1E362EC34C8500465FC8 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = AirwallexPaymentTests; sourceTree = "<group>"; };
+		D8D371942E605670005618D4 /* AirwallexPaymentSheetTests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = AirwallexPaymentSheetTests; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1151,6 +1132,7 @@
 			isa = PBXGroup;
 			children = (
 				1829B8C3291B3B7000D0D2CA /* AWXCardProviderTests.m */,
+				D81C742E2F7E1974000EDC74 /* AWX3DSServiceTests.m */,
 			);
 			path = CardTests;
 			sourceTree = "<group>";
@@ -2110,9 +2092,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-AirwallexCoreTests/Pods-AirwallexCoreTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-AirwallexCoreTests/Pods-AirwallexCoreTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -2269,6 +2255,7 @@
 				1862772129DFCC0E0002892A /* AWXUtilsTest.m in Sources */,
 				18D18C7A294222EC00E70DCD /* AWXDeviceTest.m in Sources */,
 				0829FD0E2431D3C200557DB2 /* AWXPaymentMethodTest.m in Sources */,
+				D81C742F2F7E1974000EDC74 /* AWX3DSServiceTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Airwallex/AirwallexCore/Sources/AWXConstants.h
+++ b/Airwallex/AirwallexCore/Sources/AWXConstants.h
@@ -89,7 +89,11 @@ typedef NS_ENUM(NSUInteger, AWXTextFieldType) {
 };
 
 FOUNDATION_EXPORT NSErrorDomain const AWXSDKErrorDomain;
-FOUNDATION_EXPORT NSInteger const AWXSDKErrorCodeUserCancelled;
+
+typedef NS_ENUM(NSInteger, AWXSDKErrorCode) {
+    AWXSDKErrorCodeInternalError = -1,
+    AWXSDKErrorCodeUserCancelled = NSUserCancelledError
+};
 
 FOUNDATION_EXPORT NSString *const AWXThreatMatrixOrganizationID;
 FOUNDATION_EXPORT NSString *const AWXThreatMatrixFingerprintServer;

--- a/Airwallex/AirwallexCore/Sources/AWXConstants.h
+++ b/Airwallex/AirwallexCore/Sources/AWXConstants.h
@@ -89,6 +89,7 @@ typedef NS_ENUM(NSUInteger, AWXTextFieldType) {
 };
 
 FOUNDATION_EXPORT NSErrorDomain const AWXSDKErrorDomain;
+FOUNDATION_EXPORT NSInteger const AWXSDKErrorCodeUserCancelled;
 
 FOUNDATION_EXPORT NSString *const AWXThreatMatrixOrganizationID;
 FOUNDATION_EXPORT NSString *const AWXThreatMatrixFingerprintServer;

--- a/Airwallex/AirwallexCore/Sources/AWXConstants.m
+++ b/Airwallex/AirwallexCore/Sources/AWXConstants.m
@@ -14,6 +14,7 @@
 #import "AWXPaymentMethod.h"
 
 NSErrorDomain const AWXSDKErrorDomain = @"com.airwallex.error";
+NSInteger const AWXSDKErrorCodeUserCancelled = 3072;
 
 NSString *const AWXThreatMatrixOrganizationID = @"w2txo5aa";
 NSString *const AWXThreatMatrixFingerprintServer = @"imgs.signifyd.com";

--- a/Airwallex/AirwallexCore/Sources/AWXConstants.m
+++ b/Airwallex/AirwallexCore/Sources/AWXConstants.m
@@ -14,7 +14,6 @@
 #import "AWXPaymentMethod.h"
 
 NSErrorDomain const AWXSDKErrorDomain = @"com.airwallex.error";
-NSInteger const AWXSDKErrorCodeUserCancelled = 3072;
 
 NSString *const AWXThreatMatrixOrganizationID = @"w2txo5aa";
 NSString *const AWXThreatMatrixFingerprintServer = @"imgs.signifyd.com";

--- a/Airwallex/AirwallexCore/Sources/AWXDefaultActionProvider.m
+++ b/Airwallex/AirwallexCore/Sources/AWXDefaultActionProvider.m
@@ -11,7 +11,7 @@
 @implementation AWXDefaultActionProvider
 
 - (void)handleNextAction:(AWXConfirmPaymentNextAction *)nextAction {
-    [self.delegate provider:self didCompleteWithStatus:AirwallexPaymentStatusFailure error:[NSError errorWithDomain:AWXSDKErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: @"Unknown next action type."}]];
+    [self.delegate provider:self didCompleteWithStatus:AirwallexPaymentStatusFailure error:[NSError errorWithDomain:AWXSDKErrorDomain code:AWXSDKErrorCodeInternalError userInfo:@{NSLocalizedDescriptionKey: @"Unknown next action type."}]];
 }
 
 @end

--- a/Airwallex/AirwallexCore/Sources/Card/Internal/AWX3DSActionProvider.m
+++ b/Airwallex/AirwallexCore/Sources/Card/Internal/AWX3DSActionProvider.m
@@ -62,4 +62,8 @@
     [self completeWithResponse:response error:error];
 }
 
+- (void)threeDSServiceDidCancel:(AWX3DSService *)service {
+    [self.delegate provider:self didCompleteWithStatus:AirwallexPaymentStatusCancel error:nil];
+}
+
 @end

--- a/Airwallex/AirwallexCore/Sources/Card/Internal/AWX3DSService.h
+++ b/Airwallex/AirwallexCore/Sources/Card/Internal/AWX3DSService.h
@@ -45,6 +45,13 @@ NS_ASSUME_NONNULL_BEGIN
     didFinishWithResponse:(nullable AWXConfirmPaymentIntentResponse *)response
                     error:(nullable NSError *)error;
 
+/**
+ This method is called when the user has cancelled the 3ds flow.
+
+ @param service The service handling 3ds flow.
+ */
+- (void)threeDSServiceDidCancel:(AWX3DSService *)service;
+
 @end
 
 @interface AWX3DSService : NSObject

--- a/Airwallex/AirwallexCore/Sources/Card/Internal/AWX3DSService.h
+++ b/Airwallex/AirwallexCore/Sources/Card/Internal/AWX3DSService.h
@@ -76,6 +76,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)present3DSFlowWithNextAction:(AWXConfirmPaymentNextAction *)nextAction;
 
+/**
+ Handle the web response from the 3DS webview.
+
+ @param payload The response payload if available.
+ @param error The error if the webview failed or was cancelled.
+ */
+- (void)handleWebResponsePayload:(nullable NSString *)payload error:(nullable NSError *)error;
+
 + (instancetype)allocWithZone:(struct _NSZone *)zone NS_UNAVAILABLE;
 
 @end

--- a/Airwallex/AirwallexCore/Sources/Card/Internal/AWX3DSService.m
+++ b/Airwallex/AirwallexCore/Sources/Card/Internal/AWX3DSService.m
@@ -71,6 +71,8 @@
                                                                                         __strong __typeof(weakSelf) strongSelf = weakSelf;
                                                                                         if (payload) {
                                                                                             [strongSelf confirmWithAcsResponse:payload];
+                                                                                        } else if ([error.domain isEqualToString:AWXSDKErrorDomain] && error.code == AWXSDKErrorCodeUserCancelled) {
+                                                                                            [strongSelf.delegate threeDSServiceDidCancel:strongSelf];
                                                                                         } else {
                                                                                             [strongSelf.delegate threeDSService:strongSelf didFinishWithResponse:nil error:error];
                                                                                         }

--- a/Airwallex/AirwallexCore/Sources/Card/Internal/AWX3DSService.m
+++ b/Airwallex/AirwallexCore/Sources/Card/Internal/AWX3DSService.m
@@ -69,13 +69,7 @@
                                                                                          stage:stage
                                                                                     webHandler:^(NSString *_Nullable payload, NSError *_Nullable error) {
                                                                                         __strong __typeof(weakSelf) strongSelf = weakSelf;
-                                                                                        if (payload) {
-                                                                                            [strongSelf confirmWithAcsResponse:payload];
-                                                                                        } else if ([error.domain isEqualToString:AWXSDKErrorDomain] && error.code == AWXSDKErrorCodeUserCancelled) {
-                                                                                            [strongSelf.delegate threeDSServiceDidCancel:strongSelf];
-                                                                                        } else {
-                                                                                            [strongSelf.delegate threeDSService:strongSelf didFinishWithResponse:nil error:error];
-                                                                                        }
+                                                                                        [strongSelf handleWebResponsePayload:payload error:error];
                                                                                     }];
 
     if ([stage isEqualToString:AWXThreeDSWatingDeviceDataCollection]) {
@@ -85,6 +79,16 @@
         [self.delegate threeDSService:self.delegate shouldPresentViewController:navigationController];
     } else {
         [self.delegate threeDSService:self didFinishWithResponse:nil error:[NSError errorWithDomain:AWXSDKErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: @"Invalid stage."}]];
+    }
+}
+
+- (void)handleWebResponsePayload:(nullable NSString *)payload error:(nullable NSError *)error {
+    if (payload) {
+        [self confirmWithAcsResponse:payload];
+    } else if ([error.domain isEqualToString:AWXSDKErrorDomain] && error.code == AWXSDKErrorCodeUserCancelled) {
+        [self.delegate threeDSServiceDidCancel:self];
+    } else {
+        [self.delegate threeDSService:self didFinishWithResponse:nil error:error];
     }
 }
 

--- a/Airwallex/AirwallexCore/Sources/Card/Internal/AWX3DSService.m
+++ b/Airwallex/AirwallexCore/Sources/Card/Internal/AWX3DSService.m
@@ -78,7 +78,7 @@
         UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:webViewController];
         [self.delegate threeDSService:self.delegate shouldPresentViewController:navigationController];
     } else {
-        [self.delegate threeDSService:self didFinishWithResponse:nil error:[NSError errorWithDomain:AWXSDKErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: @"Invalid stage."}]];
+        [self.delegate threeDSService:self didFinishWithResponse:nil error:[NSError errorWithDomain:AWXSDKErrorDomain code:AWXSDKErrorCodeInternalError userInfo:@{NSLocalizedDescriptionKey: @"Invalid stage."}]];
     }
 }
 

--- a/Airwallex/AirwallexCore/Sources/Card/Internal/AWX3DSViewController.m
+++ b/Airwallex/AirwallexCore/Sources/Card/Internal/AWX3DSViewController.m
@@ -74,7 +74,7 @@
     [self dismissViewControllerAnimated:YES
                              completion:^{
                                  if (self.webHandler) {
-                                     self.webHandler(nil, [NSError errorWithDomain:AWXSDKErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: @"3DS has been cancelled!"}]);
+                                     self.webHandler(nil, [NSError errorWithDomain:AWXSDKErrorDomain code:AWXSDKErrorCodeUserCancelled userInfo:@{NSLocalizedDescriptionKey: @"3DS has been cancelled by user."}]);
                                  }
                              }];
 }

--- a/Airwallex/AirwallexCore/Sources/Card/Internal/AWX3DSViewController.m
+++ b/Airwallex/AirwallexCore/Sources/Card/Internal/AWX3DSViewController.m
@@ -103,11 +103,11 @@
     NSHTTPURLResponse *response = (NSHTTPURLResponse *)navigationResponse.response;
     if (response.statusCode == 400) {
         if ([self.stage isEqualToString:AWXThreeDSWatingDeviceDataCollection]) {
-            self.webHandler(nil, [NSError errorWithDomain:AWXSDKErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: @"Unknown issue."}]);
+            self.webHandler(nil, [NSError errorWithDomain:AWXSDKErrorDomain code:AWXSDKErrorCodeInternalError userInfo:@{NSLocalizedDescriptionKey: @"Unknown issue."}]);
         } else {
             [self dismissViewControllerAnimated:YES
                                      completion:^{
-                                         self.webHandler(nil, [NSError errorWithDomain:AWXSDKErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: @"Unknown issue."}]);
+                                         self.webHandler(nil, [NSError errorWithDomain:AWXSDKErrorDomain code:AWXSDKErrorCodeInternalError userInfo:@{NSLocalizedDescriptionKey: @"Unknown issue."}]);
                                      }];
         }
     }

--- a/Airwallex/AirwallexCore/Sources/Network/AWXAPIResponse.m
+++ b/Airwallex/AirwallexCore/Sources/Network/AWXAPIResponse.m
@@ -21,7 +21,7 @@
 }
 
 - (NSError *)error {
-    return [NSError errorWithDomain:AWXSDKErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: self.message, NSLocalizedFailureReasonErrorKey: self.code}];
+    return [NSError errorWithDomain:AWXSDKErrorDomain code:AWXSDKErrorCodeInternalError userInfo:@{NSLocalizedDescriptionKey: self.message, NSLocalizedFailureReasonErrorKey: self.code}];
 }
 
 @end

--- a/Airwallex/AirwallexCoreTests/CardTests/AWX3DSServiceTests.m
+++ b/Airwallex/AirwallexCoreTests/CardTests/AWX3DSServiceTests.m
@@ -1,0 +1,101 @@
+//
+//  AWX3DSServiceTests.m
+//  AirwallexCoreTests
+//
+//  Created by Weiping Li on 2026/4/2.
+//  Copyright © 2026 Airwallex. All rights reserved.
+//
+
+#import "AWX3DSService.h"
+#import "AWXConstants.h"
+#import "AWXPaymentIntentResponse.h"
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+
+@interface AWX3DSService (Testing)
+- (void)confirmWithAcsResponse:(NSString *)acsResponse;
+@end
+
+@interface AWX3DSServiceTests : XCTestCase
+
+@property (nonatomic, strong) AWX3DSService *service;
+@property (nonatomic, strong) id mockDelegate;
+
+@end
+
+@implementation AWX3DSServiceTests
+
+- (void)setUp {
+    [super setUp];
+    self.service = [AWX3DSService new];
+    self.mockDelegate = OCMStrictProtocolMock(@protocol(AWX3DSServiceDelegate));
+    self.service.delegate = self.mockDelegate;
+}
+
+- (void)tearDown {
+    self.service = nil;
+    self.mockDelegate = nil;
+    [super tearDown];
+}
+
+#pragma mark - handleWebResponsePayload:error:
+
+- (void)testHandleWebResponse_withPayload_confirmsAcsResponse {
+    // When payload is non-nil, confirmWithAcsResponse: should be called.
+    // Since confirmWithAcsResponse: makes a network request, we use a partial mock
+    // to verify it's called without actually sending the request.
+    id partialMock = OCMPartialMock(self.service);
+    OCMExpect([partialMock confirmWithAcsResponse:@"test_payload"]);
+
+    [self.service handleWebResponsePayload:@"test_payload" error:nil];
+
+    OCMVerifyAll(partialMock);
+    [partialMock stopMocking];
+}
+
+- (void)testHandleWebResponse_withCancelError_callsDidCancel {
+    NSError *cancelError = [NSError errorWithDomain:AWXSDKErrorDomain
+                                               code:AWXSDKErrorCodeUserCancelled
+                                           userInfo:@{NSLocalizedDescriptionKey: @"3DS has been cancelled by user."}];
+
+    OCMExpect([self.mockDelegate threeDSServiceDidCancel:self.service]);
+
+    [self.service handleWebResponsePayload:nil error:cancelError];
+
+    OCMVerifyAll(self.mockDelegate);
+}
+
+- (void)testHandleWebResponse_withOtherError_callsDidFinishWithError {
+    NSError *otherError = [NSError errorWithDomain:AWXSDKErrorDomain
+                                              code:-1
+                                          userInfo:@{NSLocalizedDescriptionKey: @"Unknown issue."}];
+
+    OCMExpect([self.mockDelegate threeDSService:self.service didFinishWithResponse:nil error:otherError]);
+
+    [self.service handleWebResponsePayload:nil error:otherError];
+
+    OCMVerifyAll(self.mockDelegate);
+}
+
+- (void)testHandleWebResponse_withNilPayloadAndNilError_callsDidFinishWithNilError {
+    OCMExpect([self.mockDelegate threeDSService:self.service didFinishWithResponse:nil error:nil]);
+
+    [self.service handleWebResponsePayload:nil error:nil];
+
+    OCMVerifyAll(self.mockDelegate);
+}
+
+- (void)testHandleWebResponse_withNonAirwallexDomainCancelCode_callsDidFinishWithError {
+    // Cancel error code but wrong domain — should NOT be treated as cancel
+    NSError *wrongDomainError = [NSError errorWithDomain:@"com.other.domain"
+                                                    code:AWXSDKErrorCodeUserCancelled
+                                                userInfo:@{NSLocalizedDescriptionKey: @"Not our cancel"}];
+
+    OCMExpect([self.mockDelegate threeDSService:self.service didFinishWithResponse:nil error:wrongDomainError]);
+
+    [self.service handleWebResponsePayload:nil error:wrongDomainError];
+
+    OCMVerifyAll(self.mockDelegate);
+}
+
+@end

--- a/Airwallex/AirwallexPayment/Sources/ApplePayProvider.swift
+++ b/Airwallex/AirwallexPayment/Sources/ApplePayProvider.swift
@@ -31,9 +31,6 @@ class ApplePayProvider: PaymentProvider {
         case complete
     }
     
-    /// Indicates whether Apple Pay was launched directly
-    private var cancelPaymentOnDismiss = false
-    
     /// Indicates whether a presentation failure has already been handled
     private var didHandlePresentationFail = false
     
@@ -83,12 +80,11 @@ class ApplePayProvider: PaymentProvider {
     }
     
     /// Launch Apple Pay sheet to confirm the payment intent
-    func startPayment(cancelPaymentOnDismiss: Bool = true) throws {
+    func startPayment() throws {
         try AWXApplePayProvider.validate(paymentMethodType: paymentMethodType, session: unifiedSession)
         paymentState = .notPresented
         didHandlePresentationFail = false
         didDismissWhilePending = false
-        self.cancelPaymentOnDismiss = cancelPaymentOnDismiss
         
         let request = try unifiedSession.makePaymentRequestOrError()
 
@@ -211,9 +207,7 @@ extension ApplePayProvider: PKPaymentAuthorizationControllerDelegate {
             case .notStarted:
                 debugLog("Apple pay sheet did finished at not started status (cancelled)")
                 self.delegate?.providerDidEndRequest(self)
-                if cancelPaymentOnDismiss {
-                    delegate?.provider(self, didCompleteWith: .cancel, error: nil)
-                }
+                delegate?.provider(self, didCompleteWith: .cancel, error: nil)
             case .pending:
                 debugLog("Apple pay sheet did finished at pending status (confirming payment intent)")
                 // If UI disappears during the interaction with our API, we pass the state to the upper level

--- a/Airwallex/AirwallexPayment/Sources/PaymentSessionHandler.swift
+++ b/Airwallex/AirwallexPayment/Sources/PaymentSessionHandler.swift
@@ -169,7 +169,7 @@ public class PaymentSessionHandler: NSObject {
     /// This method sets up and starts the Apple Pay payment flow.
     func startApplePay() {
         logPaymentLaunched(AWXApplePayKey)
-        confirmApplePay(cancelPaymentOnDismiss: true)
+        confirmApplePay()
     }
     
     /// Initiates a card payment transaction.
@@ -284,11 +284,7 @@ public class PaymentSessionHandler: NSObject {
 // for internal usage
 package extension PaymentSessionHandler {
     /// Initiates an Apple Pay transaction.
-    /// - Parameter cancelPaymentOnDismiss: Determines the behavior when the Apple Pay sheet is dismissed.
-    ///   - If `true`, the standard Apple Pay flow is followed, and the payment result delegate
-    ///     receives a cancellation callback if the user dismisses the sheet.
-    ///   - If `false`, dismissing the Apple Pay sheet does not trigger a cancellation callback,
-    func confirmApplePay(cancelPaymentOnDismiss: Bool) {
+    func confirmApplePay() {
         calledMethodName = AWXApplePayKey
         let provider = providerFactory.applePayProvider(
             delegate: self,
@@ -297,7 +293,7 @@ package extension PaymentSessionHandler {
         )
         actionProvider = provider
         do {
-            try provider.startPayment(cancelPaymentOnDismiss: cancelPaymentOnDismiss)
+            try provider.startPayment()
         } catch {
             handleFailure(error)
         }
@@ -479,7 +475,6 @@ extension PaymentSessionHandler: AWXProviderDelegate {
     }
     
     public func provider(_ provider: AWXDefaultProvider, didCompleteWith status: AirwallexPaymentStatus, error: (any Error)?) {
-        viewController.stopLoading()
         debugLog("Provider: \(type(of: provider)), stauts: \(status), error: \(error?.localizedDescription ?? "N/A")")
         if paymentUIContext.hasPaymentUI {
             if let methodType, methodType.name == AWXApplePayKey, status == .inProgress {
@@ -489,6 +484,7 @@ extension PaymentSessionHandler: AWXProviderDelegate {
                 return
             }
         }
+        viewController.stopLoading()
 
         paymentResultDelegate?.paymentViewController(viewController, didCompleteWith: status, error: error)
         logPaymentComplete(status: status, error: error)

--- a/Airwallex/AirwallexPayment/Sources/PaymentSessionHandler.swift
+++ b/Airwallex/AirwallexPayment/Sources/PaymentSessionHandler.swift
@@ -483,18 +483,15 @@ extension PaymentSessionHandler: AWXProviderDelegate {
         debugLog("Provider: \(type(of: provider)), stauts: \(status), error: \(error?.localizedDescription ?? "N/A")")
         if paymentUIContext.hasPaymentUI {
             if let methodType, methodType.name == AWXApplePayKey, status == .inProgress {
-                // Remain in PaymentViewController when the Apple Pay status is .inProgress for UI integration
+                // Remain in payment session when the Apple Pay status is .inProgress
                 // This status typically occurs when the user forcefully dismisses the PKPaymentAuthorizationController—
                 // for example, by backgrounding the app—after successfully authorizing the payment.
                 return
             }
         }
-        
-        Task {
-            await paymentUIContext.completePaymentSession()
-            paymentResultDelegate?.paymentViewController(viewController, didCompleteWith: status, error: error)
-            logPaymentComplete(status: status, error: error)
-        }
+
+        paymentResultDelegate?.paymentViewController(viewController, didCompleteWith: status, error: error)
+        logPaymentComplete(status: status, error: error)
     }
     
     public func hostViewController() -> UIViewController {

--- a/Airwallex/AirwallexPayment/Sources/PaymentUIContext.swift
+++ b/Airwallex/AirwallexPayment/Sources/PaymentUIContext.swift
@@ -25,5 +25,4 @@ class PaymentUIContext: PaymentUIContextProviding {
         self.delegate = delegate
     }
 
-    func completePaymentSession() async {}
 }

--- a/Airwallex/AirwallexPayment/Sources/PaymentUIContextProviding.swift
+++ b/Airwallex/AirwallexPayment/Sources/PaymentUIContextProviding.swift
@@ -18,5 +18,4 @@ package protocol PaymentUIContextProviding: AnyObject {
 /// Whether the payment is running within a UI context (payment sheet or embedded element).
     /// Used to decide whether to keep the payment UI alive on intermediate statuses like `.inProgress`.
     var hasPaymentUI: Bool { get }
-    func completePaymentSession() async
 }

--- a/Airwallex/AirwallexPayment/Sources/ProviderFactory.swift
+++ b/Airwallex/AirwallexPayment/Sources/ProviderFactory.swift
@@ -83,21 +83,12 @@ final class ProviderFactory: ProviderFactoryProtocol {
 }
 
 protocol ApplePayProviderProtocol: AWXDefaultProvider {
-    func startPayment(cancelPaymentOnDismiss: Bool) throws
+    func startPayment() throws
 }
 
 extension ApplePayProvider: ApplePayProviderProtocol {}
 
-extension AWXApplePayProvider: ApplePayProviderProtocol {
-    func startPayment(cancelPaymentOnDismiss: Bool) throws {
-        try validate()
-        if cancelPaymentOnDismiss {
-            startPayment()
-        } else {
-            handleFlow()
-        }
-    }
-}
+extension AWXApplePayProvider: ApplePayProviderProtocol {}
 
 protocol CardProviderProtocol: AWXDefaultProvider {
     

--- a/Airwallex/AirwallexPaymentSheet/Sources/PaymentSheet/PaymentSections/ApplePaySectionController.swift
+++ b/Airwallex/AirwallexPaymentSheet/Sources/PaymentSheet/PaymentSections/ApplePaySectionController.swift
@@ -126,7 +126,7 @@ class ApplePaySectionController: PaymentSectionController {
             paymentUIContext: paymentUIContext
         )
         prepareForEmbeddedCheckout(paymentMethod: AWXApplePayKey, handler: paymentSessionHandler)
-        paymentSessionHandler?.confirmApplePay(cancelPaymentOnDismiss: paymentUIContext.isEmbedded)
+        paymentSessionHandler?.confirmApplePay()
     }
 
     func collectionView(didSelectItem sectionItem: SectionItem, at indexPath: IndexPath) {

--- a/Airwallex/AirwallexPaymentSheet/Sources/PaymentSheet/PaymentSessionHandlerFactory.swift
+++ b/Airwallex/AirwallexPaymentSheet/Sources/PaymentSheet/PaymentSessionHandlerFactory.swift
@@ -31,8 +31,7 @@ protocol PaymentSessionHandlerProtocol: AnyObject {
     func confirmConsentPayment(with consent: AWXPaymentConsent)
 
     /// Initiates an Apple Pay transaction.
-    /// - Parameter cancelPaymentOnDismiss: Whether to trigger cancellation callback when dismissed.
-    func confirmApplePay(cancelPaymentOnDismiss: Bool)
+    func confirmApplePay()
 
     /// Initiates a schema-based redirect payment.
     /// - Parameter paymentMethod: The payment method with all required information.

--- a/Airwallex/AirwallexPaymentSheet/Sources/PaymentSheet/PaymentViewController.swift
+++ b/Airwallex/AirwallexPaymentSheet/Sources/PaymentSheet/PaymentViewController.swift
@@ -31,28 +31,33 @@ class PaymentViewController: AWXViewController {
 
     let paymentUIContext: PaymentSheetUIContext
 
+    /// The merchant's result delegate, stored separately because paymentUIContext.delegate is set to self.
+    private weak var paymentResultDelegate: AWXPaymentResultDelegate?
+
     init(methodProvider: PaymentMethodProvider,
          paymentUIContext: PaymentSheetUIContext) {
         self.methodProvider = methodProvider
         self.paymentUIContext = paymentUIContext
+        self.paymentResultDelegate = paymentUIContext.delegate
         self.layout = paymentUIContext.layout
         super.init(nibName: nil, bundle: nil)
         self.session = methodProvider.session
         self.paymentUIContext.viewController = self
+        self.paymentUIContext.delegate = self
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     deinit {
-        Task { @MainActor [paymentUIContext] in
+        Task { @MainActor [paymentUIContext, paymentResultDelegate] in
             if paymentUIContext.dismissAction != nil {
                 await paymentUIContext.completePaymentSession()
                 // this fallback logic handles user cancel payment by navigation stack interactions
                 // e.g. screen edge pan gesture
                 AnalyticsLogger.log(action: .paymentCanceled)
-                paymentUIContext.delegate?.paymentViewController(nil, didCompleteWith: .cancel, error: nil)
+                paymentResultDelegate?.paymentViewController(nil, didCompleteWith: .cancel, error: nil)
             }
         }
     }
@@ -141,8 +146,10 @@ class PaymentViewController: AWXViewController {
     }
     
     @objc func onCloseButtonTapped() {
-        dismiss(animated: true) {
-            self.paymentUIContext.delegate?.paymentViewController(self, didCompleteWith: .cancel, error: nil)
+        Task {
+            await paymentUIContext.completePaymentSession()
+            AnalyticsLogger.log(action: .paymentCanceled)
+            paymentResultDelegate?.paymentViewController(self, didCompleteWith: .cancel, error: nil)
         }
     }
     
@@ -163,7 +170,7 @@ class PaymentViewController: AWXViewController {
                     }
                     Task {
                         await self.paymentUIContext.completePaymentSession()
-                        self.paymentUIContext.delegate?.paymentViewController(self, didCompleteWith: .failure, error: error)
+                        self.paymentResultDelegate?.paymentViewController(self, didCompleteWith: .failure, error: error)
                     }
                 }
             }
@@ -172,6 +179,30 @@ class PaymentViewController: AWXViewController {
     
     override func activeScrollView() -> UIScrollView {
         return collectionViewManager.collectionView
+    }
+}
+
+extension PaymentViewController: AWXPaymentResultDelegate {
+    public func paymentViewController(
+        _ controller: UIViewController?,
+        didCompleteWith status: AirwallexPaymentStatus,
+        error: (any Error)?
+    ) {
+        if status == .cancel {
+            // Stay in payment flow (e.g. 3DS cancel, Apple Pay cancel)
+            return
+        }
+        Task {
+            await paymentUIContext.completePaymentSession()
+            paymentResultDelegate?.paymentViewController(self, didCompleteWith: status, error: error)
+        }
+    }
+
+    public func paymentViewController(
+        _ controller: UIViewController?,
+        didCompleteWithPaymentConsentId paymentConsentId: String
+    ) {
+        paymentResultDelegate?.paymentViewController?(self, didCompleteWithPaymentConsentId: paymentConsentId)
     }
 }
 

--- a/Airwallex/AirwallexPaymentSheetTests/MockObjects/MockPaymentSessionHandler.swift
+++ b/Airwallex/AirwallexPaymentSheetTests/MockObjects/MockPaymentSessionHandler.swift
@@ -29,7 +29,6 @@ class MockPaymentSessionHandler: PaymentSessionHandlerProtocol {
     var confirmConsentPaymentConsent: AWXPaymentConsent?
 
     var confirmApplePayCalled = false
-    var confirmApplePayCancelOnDismiss: Bool?
 
     var confirmRedirectPaymentCalled = false
     var confirmRedirectPaymentMethod: AWXPaymentMethod?
@@ -48,9 +47,8 @@ class MockPaymentSessionHandler: PaymentSessionHandlerProtocol {
         confirmConsentPaymentConsent = consent
     }
 
-    func confirmApplePay(cancelPaymentOnDismiss: Bool) {
+    func confirmApplePay() {
         confirmApplePayCalled = true
-        confirmApplePayCancelOnDismiss = cancelPaymentOnDismiss
     }
 
     func confirmRedirectPayment(with paymentMethod: AWXPaymentMethod) async {
@@ -69,7 +67,6 @@ class MockPaymentSessionHandler: PaymentSessionHandlerProtocol {
         confirmConsentPaymentCalled = false
         confirmConsentPaymentConsent = nil
         confirmApplePayCalled = false
-        confirmApplePayCancelOnDismiss = nil
         confirmRedirectPaymentCalled = false
         confirmRedirectPaymentMethod = nil
     }

--- a/Airwallex/AirwallexPaymentSheetTests/PaymentSheetTests/PaymentSections/ApplePaySectionControllerTests.swift
+++ b/Airwallex/AirwallexPaymentSheetTests/PaymentSheetTests/PaymentSections/ApplePaySectionControllerTests.swift
@@ -245,7 +245,6 @@ import XCTest
 
         XCTAssertTrue(mockFactory.createHandlerCalled)
         XCTAssertTrue(mockFactory.mockHandler.confirmApplePayCalled)
-        XCTAssertEqual(mockFactory.mockHandler.confirmApplePayCancelOnDismiss, false)
     }
 
     func testCheckout_Embedded_CallsConfirmApplePayWithCancelOnDismissTrue() {
@@ -263,7 +262,6 @@ import XCTest
         applePayController.checkout()
 
         XCTAssertTrue(mockFactory.mockHandler.confirmApplePayCalled)
-        XCTAssertEqual(mockFactory.mockHandler.confirmApplePayCancelOnDismiss, true)
     }
 
     func testCheckout_Embedded_SetsShowIndicatorFalse() {

--- a/Airwallex/AirwallexPaymentTests/ApplePayProviderTests.swift
+++ b/Airwallex/AirwallexPaymentTests/ApplePayProviderTests.swift
@@ -333,7 +333,7 @@ class ApplePayProviderTests: XCTestCase {
         XCTAssertEqual(provider.paymentState, .notPresented)
         
         // Start payment to initialize controller
-        try? provider.startPayment(cancelPaymentOnDismiss: true)
+        try? provider.startPayment()
         
         // Wait for async operations
         try? await Task.sleep(nanoseconds: 500_000_000)

--- a/Airwallex/AirwallexPaymentTests/MockObjects/MockApplePayProvider.swift
+++ b/Airwallex/AirwallexPaymentTests/MockObjects/MockApplePayProvider.swift
@@ -12,7 +12,6 @@ import Foundation
 
 class MockApplePayProvider: AWXDefaultProvider, ApplePayProviderProtocol {
     var startPaymentCalled = false
-    var cancelPaymentOnDismissValue = false
     var shouldSucceed = true
     var resultStatus: AirwallexPaymentStatus = .failure
 
@@ -26,9 +25,8 @@ class MockApplePayProvider: AWXDefaultProvider, ApplePayProviderProtocol {
         super.init(delegate: delegate, session: session, paymentMethodType: methodType)
     }
 
-    func startPayment(cancelPaymentOnDismiss: Bool) throws {
+    func startPayment() throws {
         startPaymentCalled = true
-        cancelPaymentOnDismissValue = cancelPaymentOnDismiss
 
         // Simulate the flow by calling delegate methods
         Task { @MainActor in

--- a/Airwallex/AirwallexPaymentTests/PaymentSessionHandlerTests.swift
+++ b/Airwallex/AirwallexPaymentTests/PaymentSessionHandlerTests.swift
@@ -831,7 +831,7 @@ class PaymentSessionHandlerTests: XCTestCase {
         // Verify the mock provider was used
         XCTAssertTrue(mockFactory.applePayProviderCalled)
         XCTAssertTrue(mockApplePayProvider.startPaymentCalled)
-        XCTAssertTrue(mockApplePayProvider.cancelPaymentOnDismissValue)
+        // cancelPaymentOnDismiss removed — cancel always propagates
     }
     // MARK: - Card Payment Happy Path Test
     

--- a/Airwallex/AirwallexPaymentTests/PaymentUIContextTests.swift
+++ b/Airwallex/AirwallexPaymentTests/PaymentUIContextTests.swift
@@ -13,9 +13,4 @@ import XCTest
 
 @MainActor
 final class PaymentUIContextTests: XCTestCase {
-
-    func testCompletePaymentSession_DoesNotCrash() async {
-        let context = PaymentUIContext()
-        await context.completePaymentSession()
-    }
 }

--- a/Airwallex/AirwallexWeChatPay/AWXWeChatPayActionProvider.m
+++ b/Airwallex/AirwallexWeChatPay/AWXWeChatPayActionProvider.m
@@ -60,7 +60,7 @@
                     [[AWXAnalyticsLogger shared] logErrorWithName:@"wechat_redirect" additionalInfo:@{@"message": request.description}];
                 }
 
-                [self.delegate provider:self didCompleteWithStatus:AirwallexPaymentStatusFailure error:[NSError errorWithDomain:AWXSDKErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: @"Failed to request WeChat service."}]];
+                [self.delegate provider:self didCompleteWithStatus:AirwallexPaymentStatusFailure error:[NSError errorWithDomain:AWXSDKErrorDomain code:AWXSDKErrorCodeInternalError userInfo:@{NSLocalizedDescriptionKey: @"Failed to request WeChat service."}]];
                 [self log:@"Delegate: %@, provider:didCompleteWithStatus:error:  %lu  %@", self.delegate.class, AirwallexPaymentStatusFailure, @"Failed to request WeChat service."];
                 return;
             }

--- a/Examples/ExamplesUITests/CardGuestUserCheckoutTests.swift
+++ b/Examples/ExamplesUITests/CardGuestUserCheckoutTests.swift
@@ -99,6 +99,6 @@ final class CardGuestUserCheckoutTests: XCTestCase {
         )
         ThreeDSScreen.waitForExistence(.longLongTimeout)
         ThreeDSScreen.cancelThreeDS()
-        UIIntegrationDemoScreen.verifyAlertForPaymentStatus(.failure)
+        PaymentSheetScreen.validate()
     }
 }


### PR DESCRIPTION
## Summary
- When user taps close on the 3DS webview, emit `AirwallexPaymentStatusCancel` instead of `AirwallexPaymentStatusFailure` by introducing `AWXSDKErrorCodeUserCancelled` error code and `threeDSServiceDidCancel:` delegate method
- Make `PaymentViewController` the result delegate of `PaymentSessionHandler` — it intercepts cancel to stay in the payment flow, and forwards success/failure to the merchant delegate after dismissing the sheet
- Remove `cancelPaymentOnDismiss` workaround from Apple Pay — cancel always propagates, `PaymentViewController` handles the "stay or dismiss" decision
- Remove `completePaymentSession()` from `PaymentUIContextProviding` protocol (now only used on `PaymentSheetUIContext` directly)

## Behavior
| Scenario | Payment Sheet | Embedded Element | Low-level API |
|---|---|---|---|
| 3DS cancel | Stays in flow | Callback `.cancel` | Callback `.cancel` |
| Apple Pay cancel | Stays in flow | Callback `.cancel` | Callback `.cancel` |
| Success / Failure | Dismisses → callback | Callback | Callback |

## Test plan
- [ ] Build succeeds
- [ ] Existing unit tests pass
- [ ] Manual: Launch payment sheet → trigger 3DS → tap close → verify sheet stays open
- [ ] Manual: Launch embedded element → trigger 3DS → tap close → verify `.cancel` callback
- [ ] Manual: Launch payment sheet → Apple Pay → cancel → verify sheet stays open
- [ ] Manual: Launch embedded element → Apple Pay → cancel → verify `.cancel` callback

🤖 Generated with [Claude Code](https://claude.com/claude-code)