### PR TITLE
[APAM-651] Validate empty customerId and add fallback logic

### DIFF
--- a/Airwallex/AirwallexCore/Sources/Network/AWXPaymentIntentRequest.m
+++ b/Airwallex/AirwallexCore/Sources/Network/AWXPaymentIntentRequest.m
@@ -29,7 +29,7 @@
 - (nullable NSDictionary *)parameters {
     NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
     parameters[@"request_id"] = self.requestId;
-    if (self.customerId) {
+    if (self.customerId.length > 0) {
         parameters[@"customer_id"] = self.customerId;
     }
 

--- a/Airwallex/AirwallexCoreTests/AWXPaymentIntentRequestTest.m
+++ b/Airwallex/AirwallexCoreTests/AWXPaymentIntentRequestTest.m
@@ -134,6 +134,33 @@
     XCTAssertNotNil(parameters[@"payment_method"]);
 }
 
+- (void)testConfirmRequestWithCustomerId {
+    AWXConfirmPaymentIntentRequest *request = [AWXConfirmPaymentIntentRequest new];
+    request.intentId = @"int_123456";
+    request.customerId = @"cus_abc123";
+
+    NSDictionary *parameters = request.parameters;
+    XCTAssertEqualObjects(parameters[@"customer_id"], @"cus_abc123");
+}
+
+- (void)testConfirmRequestWithNilCustomerId {
+    AWXConfirmPaymentIntentRequest *request = [AWXConfirmPaymentIntentRequest new];
+    request.intentId = @"int_123456";
+    request.customerId = nil;
+
+    NSDictionary *parameters = request.parameters;
+    XCTAssertNil(parameters[@"customer_id"]);
+}
+
+- (void)testConfirmRequestWithEmptyCustomerId {
+    AWXConfirmPaymentIntentRequest *request = [AWXConfirmPaymentIntentRequest new];
+    request.intentId = @"int_123456";
+    request.customerId = @"";
+
+    NSDictionary *parameters = request.parameters;
+    XCTAssertNil(parameters[@"customer_id"]);
+}
+
 - (void)testConfirmRequestPath {
     // Test the path method of AWXConfirmPaymentIntentRequest
     AWXConfirmPaymentIntentRequest *request = [AWXConfirmPaymentIntentRequest new];

--- a/Airwallex/AirwallexPayment/Sources/CardProvider.swift
+++ b/Airwallex/AirwallexPayment/Sources/CardProvider.swift
@@ -36,7 +36,7 @@ class CardProvider: PaymentProvider {
             method.card = card
             method.customerId = unifiedSession.customerId()
 
-            let consentOptions = if saveCard && unifiedSession.customerId() != nil {
+            let consentOptions = if saveCard, let customerId = unifiedSession.customerId(), !customerId.isEmpty {
                 PaymentConsentOptions(nextTriggeredBy: .customerType)
             } else {
                 unifiedSession.paymentConsentOptions

--- a/Airwallex/AirwallexPayment/Sources/Extensions/AWXSession+Extensions.swift
+++ b/Airwallex/AirwallexPayment/Sources/Extensions/AWXSession+Extensions.swift
@@ -116,6 +116,13 @@ public extension AWXSession {
                 }
             }
         }
+        if let customerId = customerId() {
+            guard !customerId.isEmpty else {
+                throw ValidationError.invalidCustomerId(
+                    "Customer ID should never be empty string"
+                )
+            }
+        }
     }
     
     private func validate(paymentIntent: AWXPaymentIntent?) throws {

--- a/Airwallex/AirwallexPaymentSheet/Sources/PaymentSheet/MethodProvider/PaymentSheetMethodProvider.swift
+++ b/Airwallex/AirwallexPaymentSheet/Sources/PaymentSheet/MethodProvider/PaymentSheetMethodProvider.swift
@@ -111,6 +111,7 @@ private extension PaymentSheetMethodProvider {
     
     func getAllConsents() async throws -> [AWXPaymentConsent] {
         guard let customerId = session.customerId(),
+              !customerId.isEmpty,
               !session.hidePaymentConsents,
               !(session is AWXRecurringSession) else {
             return []

--- a/Airwallex/AirwallexPaymentSheetTests/PaymentSheetTests/MethodProviderTests/PaymentSheetMethodProviderTests.swift
+++ b/Airwallex/AirwallexPaymentSheetTests/PaymentSheetTests/MethodProviderTests/PaymentSheetMethodProviderTests.swift
@@ -254,6 +254,22 @@ import XCTest
         }
     }
     
+    func testFetchPaymentConsentsWithEmptyCustomerId() async {
+        mockPaymentIntent.customerId = ""
+        mockOneOffSession.paymentIntent = mockPaymentIntent
+        MockURLProtocol.mockResponseMap = [
+            AWXGetPaymentMethodTypesRequest().path(): (mockMethodTypesData, mockSuccessResponse, nil),
+            AWXGetPaymentConsentsRequest().path(): (mockConsentsData, mockSuccessResponse, nil)
+        ]
+        do {
+            try await provider.getPaymentMethodTypes()
+        } catch {
+            XCTFail()
+        }
+
+        XCTAssertEqual(provider.consents.count, 0)
+    }
+
     func testChangeSelectedMethod() async {
         MockURLProtocol.mockResponseMap = [
             AWXGetPaymentMethodTypesRequest().path(): (mockMethodTypesData, mockSuccessResponse, nil),

--- a/Airwallex/AirwallexPaymentTests/AWXSessionExtensionTests.swift
+++ b/Airwallex/AirwallexPaymentTests/AWXSessionExtensionTests.swift
@@ -247,6 +247,36 @@ class AWXSessionExtensionTests: XCTestCase {
         XCTAssertThrowsError(try session.validate())
     }
     
+    func testValidateOneOffSessionWithEmptyCustomerId() {
+        mockPaymentIntent.customerId = ""
+        let session = AWXOneOffSession()
+        session.countryCode = "AU"
+        session.paymentIntent = mockPaymentIntent
+
+        XCTAssertThrowsError(try session.validate()) { error in
+            guard case AWXSession.ValidationError.invalidCustomerId(_) = error else {
+                XCTFail("Expected invalidCustomerId error, got: \(error.localizedDescription)")
+                return
+            }
+        }
+    }
+
+    func testValidateSessionWithEmptyCustomerId() {
+        mockPaymentIntent.customerId = ""
+        let session = Session(
+            paymentIntent: mockPaymentIntent,
+            countryCode: "AU",
+            returnURL: AWXThreeDSReturnURL
+        )
+
+        XCTAssertThrowsError(try session.validate()) { error in
+            guard case AWXSession.ValidationError.invalidCustomerId(_) = error else {
+                XCTFail("Expected invalidCustomerId error, got: \(error.localizedDescription)")
+                return
+            }
+        }
+    }
+
     func testValidateSessionAmount() {
         mockPaymentIntent.amount = NSDecimalNumber(0)
         let session = Session(


### PR DESCRIPTION
## Summary
- Add validation in `AWXSession.validate()` that throws `invalidCustomerId` error when `customerId` is an empty string (should be `nil` for guest checkout)
- Treat empty `customerId` as `nil` in `AWXConfirmPaymentIntentRequest` parameter serialization as a fallback
- Guard against empty `customerId` in `CardProvider` consent options logic

## Test plan
- [ ] Verify one-off session with empty `customerId` throws validation error
- [ ] Verify one-off session with `nil` `customerId` (guest checkout) passes validation
- [ ] Verify confirm payment intent request omits `customer_id` param when `customerId` is empty string
- [ ] Run unit tests for `AWXPaymentIntentRequestTest` and `AWXSessionExtensionTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)