### PR TITLE
[APAM-658] Adopt UIScene lifecycle and unify key window lookup

### DIFF
--- a/Airwallex/AirwallexCore/Sources/ApplePay/AWXApplePayProvider.m
+++ b/Airwallex/AirwallexCore/Sources/ApplePay/AWXApplePayProvider.m
@@ -87,21 +87,14 @@ typedef enum {
 #pragma mark - PKPaymentAuthorizationControllerDelegate
 
 - (UIWindow *)presentationWindowForPaymentAuthorizationController:(PKPaymentAuthorizationController *)controller {
-    if (@available(iOS 15.0, *)) {
-        for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
-            if ([scene isKindOfClass:[UIWindowScene class]]) {
-                UIWindowScene *windowScene = (UIWindowScene *)scene;
-                for (UIWindow *window in windowScene.windows) {
-                    if (window.isKeyWindow) {
-                        return window;
-                    }
+    for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+        if ([scene isKindOfClass:[UIWindowScene class]]) {
+            UIWindowScene *windowScene = (UIWindowScene *)scene;
+            for (UIWindow *window in windowScene.windows) {
+                if (window.isKeyWindow) {
+                    return window;
                 }
             }
-        }
-    }
-    for (UIWindow *window in UIApplication.sharedApplication.windows) {
-        if (window.isKeyWindow) {
-            return window;
         }
     }
     return nil;

--- a/Airwallex/AirwallexPayment/Sources/ApplePayProvider.swift
+++ b/Airwallex/AirwallexPayment/Sources/ApplePayProvider.swift
@@ -185,14 +185,7 @@ class ApplePayProvider: PaymentProvider {
 extension ApplePayProvider: PKPaymentAuthorizationControllerDelegate {
 
     func presentationWindow(for controller: PKPaymentAuthorizationController) -> UIWindow? {
-        if #available(iOS 15.0, *) {
-            return UIApplication.shared.connectedScenes
-                .compactMap { $0 as? UIWindowScene }
-                .flatMap { $0.windows }
-                .first { $0.isKeyWindow }
-        } else {
-            return UIApplication.shared.windows.first { $0.isKeyWindow }
-        }
+        UIApplication.shared.keyWindow
     }
 
     func paymentAuthorizationController(_ controller: PKPaymentAuthorizationController,

--- a/Airwallex/AirwallexPayment/Sources/UI/UIViewController+Extensions.swift
+++ b/Airwallex/AirwallexPayment/Sources/UI/UIViewController+Extensions.swift
@@ -8,6 +8,15 @@
 
 import UIKit
 
+package extension UIApplication {
+    var keyWindow: UIWindow? {
+        connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first { $0.isKeyWindow }
+    }
+}
+
 package extension UIViewController {
     func startLoading() {
         view.startLoading()
@@ -24,14 +33,7 @@ package extension UIViewController {
 
 package extension UIViewController {
     static var topMost: UIViewController? {
-        let windowScene = UIApplication.shared.connectedScenes.first(where: { $0 is UIWindowScene }) as? UIWindowScene
-        let keyWindow: UIWindow?
-        if #available(iOS 15.0, *) {
-            keyWindow = windowScene?.keyWindow
-        } else {
-            keyWindow = windowScene?.windows.first(where: { $0.isKeyWindow })
-        }
-        let rootVC = keyWindow?.rootViewController
+        let rootVC = UIApplication.shared.keyWindow?.rootViewController
 
         return UIViewController.topMost(from: rootVC)
     }

--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		D8D506512E3CB7060098CACD /* CardRegisteredUserCheckoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D506442E3CB7060098CACD /* CardRegisteredUserCheckoutTests.swift */; };
 		D8D506522E3CB7060098CACD /* UITestingUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D506452E3CB7060098CACD /* UITestingUtils.swift */; };
 		D8EB808A2D67067200C2F975 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8EB80892D67067200C2F975 /* AppDelegate.swift */; };
+		D8EB808C2D67067200C2F976 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8EB808B2D67067200C2F976 /* SceneDelegate.swift */; };
 		D8F268C12EF2A00100E84D64 /* UIIntegrationDemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F268C02EF2A00100E84D64 /* UIIntegrationDemoViewController.swift */; };
 		D8F268C32EF2A00100E84D64 /* APIIntegrationDemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F268C22EF2A00100E84D64 /* APIIntegrationDemoViewController.swift */; };
 		D8F268C52EF2A00100E84D64 /* EmbeddedIntegrationDemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F268C42EF2A00100E84D64 /* EmbeddedIntegrationDemoViewController.swift */; };
@@ -192,6 +193,7 @@
 		D8D506442E3CB7060098CACD /* CardRegisteredUserCheckoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardRegisteredUserCheckoutTests.swift; sourceTree = "<group>"; };
 		D8D506452E3CB7060098CACD /* UITestingUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestingUtils.swift; sourceTree = "<group>"; };
 		D8EB80892D67067200C2F975 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		D8EB808B2D67067200C2F976 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		D8F268B32DDADDE000E84D64 /* ExamplesUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExamplesUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D8F268C02EF2A00100E84D64 /* UIIntegrationDemoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIIntegrationDemoViewController.swift; sourceTree = "<group>"; };
 		D8F268C22EF2A00100E84D64 /* APIIntegrationDemoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIIntegrationDemoViewController.swift; sourceTree = "<group>"; };
@@ -244,6 +246,7 @@
 				3C5A37D427EAF68F00CFC2EF /* Examples.entitlements */,
 				D8B38C262D9E5F2B00909ADD /* Keys */,
 				D8EB80892D67067200C2F975 /* AppDelegate.swift */,
+				D8EB808B2D67067200C2F976 /* SceneDelegate.swift */,
 				D80F0E282D5C856600401BA6 /* ExamplesKeys.swift */,
 				D81EAF792D3F8BB100B44784 /* Views */,
 				D872B35B2D5EDB43007BC089 /* Controllers */,
@@ -695,6 +698,7 @@
 				D89C7AF32D424C890042FC3B /* SettingsViewController.swift in Sources */,
 				D8A14A9A2EEA6C3F0071A84E /* PaymentAttempt.swift in Sources */,
 				D8EB808A2D67067200C2F975 /* AppDelegate.swift in Sources */,
+				D8EB808C2D67067200C2F976 /* SceneDelegate.swift in Sources */,
 				D80F0E292D5C856600401BA6 /* ExamplesKeys.swift in Sources */,
 				D80F0E332D5DD04C00401BA6 /* DemoDataSource.swift in Sources */,
 				D81EAF692D3F474100B44784 /* UIViewController+Extensions.swift in Sources */,

--- a/Examples/Examples/AppDelegate.swift
+++ b/Examples/Examples/AppDelegate.swift
@@ -15,106 +15,29 @@ import WechatOpenSDKDynamic
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    
-    var window: UIWindow?
-    
+
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         //  initialize
         ExamplesKeys.loadDefaultKeysIfNilOrEmpty()
         Airwallex.setMode(ExamplesKeys.environment)
-        
+
 #if canImport(WechatOpenSDKDynamic)
         WXApi.registerApp("wx4c86d73fe4f82431", universalLink: "https://airwallex.com/")
         WXApi.startLog(by: .normal) { log in
             print("WeChat Log: \(log)")
         }
 #endif
-        //  customize theme color of the payment UI by setting tintColor on AWXTheme
-//        AWXTheme.shared().tintColor = UIColor.systemBrown
+
         UISwitch.appearance().onTintColor = .awxColor(.theme)
         UIView.appearance().tintColor = .awxColor(.theme)
 //        AnalyticsLogger.shared().verbose = true
 
-        disableAnimationForUITesting()
         return true
     }
-    
-    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
-        NotificationCenter.default.post(name: PaymentResultViewController.paymentResultNotification, object: nil)
-#if canImport(WechatOpenSDKDynamic)
-        if WXApi.handleOpen(url, delegate: self) {
-            return true
-        } else {
-            return handleAirwallexDemoSchema(url)
-        }
-#else
-        return handleSchemaURL(url)
-#endif
-    }
-    
-    private func handleAirwallexDemoSchema(_ url: URL) -> Bool {
-        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
-              components.scheme == String.demoAppScheme,
-              components.host == String.demoAppHost else {
-            return false
-        }
-        guard let type = components.queryItems?.first(where: { $0.name == "type" })?.value else {
-            print("APP launched by URL: \(url.absoluteString)")
-            return true
-        }
-        
-        switch type {
-        case "SUCCESS_URL":
-            let intentId = components.queryItems?.first(where: { $0.name == "id" })?.value ?? "Not Found"
-            window?.rootViewController?.showAlert(message: "intentId: \(intentId)", title: "Payment Success") {
-                UIPasteboard.general.string = intentId
-            }
-        case "FAIL_URL":
-            let intentId = components.queryItems?.first(where: { $0.name == "id" })?.value ?? "Not Found"
-            let error = components.queryItems?.first(where: { $0.name == "error" })?.value ?? "Not Found"
-            window?.rootViewController?.showAlert(message: "error: \(error), intentId: \(intentId)", title: "Payment Failed") {
-                UIPasteboard.general.string = intentId
-            }
-        default:
-            window?.rootViewController?.showAlert(message: url.absoluteString, title: type)
-        }
-        return true
-    }
-    
-    fileprivate func disableAnimationForUITesting() {
-        if ProcessInfo.processInfo.environment[UITestingEnvironmentVariable.isUITesting] == "1" {
-            // disable animation for robust UI testing
-            UIView.setAnimationsEnabled(false)
-            UIWindow.appearance().layer.speed = 100
-            CATransaction.setAnimationDuration(0)
-            window?.layer.speed = 100
-        }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
 }
-
-#if canImport(WechatOpenSDKDynamic)
-extension AppDelegate: WXApiDelegate {
-    
-    func onResp(_ resp: BaseResp) {
-        if let response = resp as? PayResp {
-            var message: String
-
-            switch response.errCode {
-            case WXSuccess.rawValue:
-                message = "Succeed to pay"
-            case WXErrCodeUserCancel.rawValue:
-                message = "User cancelled."
-            default:
-                message = "Failed to pay"
-            }
-
-            let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-            alertController.addAction(UIAlertAction(title: "Close", style: .cancel))
-
-            if let rootViewController = UIApplication.shared.windows.first?.rootViewController {
-                rootViewController.present(alertController, animated: true, completion: nil)
-            }
-        }
-    }
-}
-#endif

--- a/Examples/Examples/Info.plist
+++ b/Examples/Examples/Info.plist
@@ -73,8 +73,25 @@
 	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/Examples/Examples/SceneDelegate.swift
+++ b/Examples/Examples/SceneDelegate.swift
@@ -1,0 +1,104 @@
+//
+//  SceneDelegate.swift
+//  Examples
+//
+//  Created by Weiping Li on 2025/2/20.
+//  Copyright © 2025 Airwallex. All rights reserved.
+//
+
+import UIKit
+
+#if canImport(WechatOpenSDKDynamic)
+import WechatOpenSDKDynamic
+#endif
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        disableAnimationForUITesting()
+        // Handle URLs passed at launch
+        if let urlContext = connectionOptions.urlContexts.first {
+            handleURL(urlContext.url)
+        }
+    }
+
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        guard let url = URLContexts.first?.url else { return }
+        handleURL(url)
+    }
+
+    private func handleURL(_ url: URL) {
+        NotificationCenter.default.post(name: PaymentResultViewController.paymentResultNotification, object: nil)
+#if canImport(WechatOpenSDKDynamic)
+        if !WXApi.handleOpen(url, delegate: self) {
+            handleAirwallexDemoSchema(url)
+        }
+#else
+        handleAirwallexDemoSchema(url)
+#endif
+    }
+
+    private func handleAirwallexDemoSchema(_ url: URL) {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              components.scheme == String.demoAppScheme,
+              components.host == String.demoAppHost else {
+            return
+        }
+        guard let type = components.queryItems?.first(where: { $0.name == "type" })?.value else {
+            print("APP launched by URL: \(url.absoluteString)")
+            return
+        }
+
+        switch type {
+        case "SUCCESS_URL":
+            let intentId = components.queryItems?.first(where: { $0.name == "id" })?.value ?? "Not Found"
+            window?.rootViewController?.showAlert(message: "intentId: \(intentId)", title: "Payment Success") {
+                UIPasteboard.general.string = intentId
+            }
+        case "FAIL_URL":
+            let intentId = components.queryItems?.first(where: { $0.name == "id" })?.value ?? "Not Found"
+            let error = components.queryItems?.first(where: { $0.name == "error" })?.value ?? "Not Found"
+            window?.rootViewController?.showAlert(message: "error: \(error), intentId: \(intentId)", title: "Payment Failed") {
+                UIPasteboard.general.string = intentId
+            }
+        default:
+            window?.rootViewController?.showAlert(message: url.absoluteString, title: type)
+        }
+    }
+
+    private func disableAnimationForUITesting() {
+        if ProcessInfo.processInfo.environment[UITestingEnvironmentVariable.isUITesting] == "1" {
+            UIView.setAnimationsEnabled(false)
+            UIWindow.appearance().layer.speed = 100
+            CATransaction.setAnimationDuration(0)
+            window?.layer.speed = 100
+        }
+    }
+}
+
+#if canImport(WechatOpenSDKDynamic)
+extension SceneDelegate: WXApiDelegate {
+
+    func onResp(_ resp: BaseResp) {
+        if let response = resp as? PayResp {
+            var message: String
+
+            switch response.errCode {
+            case WXSuccess.rawValue:
+                message = "Succeed to pay"
+            case WXErrCodeUserCancel.rawValue:
+                message = "User cancelled."
+            default:
+                message = "Failed to pay"
+            }
+
+            let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+            alertController.addAction(UIAlertAction(title: "Close", style: .cancel))
+
+            window?.rootViewController?.present(alertController, animated: true, completion: nil)
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Add `UIApplication.keyWindow` extension to unify key window lookup across `ApplePayProvider` (Swift), `AWXApplePayProvider` (ObjC), and `UIViewController.topMost`, removing duplicated and deprecated `UIApplication.shared.windows` usage
- Refactor Examples app from AppDelegate-only lifecycle to UIScene-based lifecycle with a new `SceneDelegate` handling window ownership, URL contexts, and WeChat callbacks
- Fix undefined `handleSchemaURL` call when WechatOpenSDKDynamic is not available

## Test plan
- [ ] Build Examples scheme on simulator
- [ ] Launch app and verify HomeViewController loads as root
- [ ] Test deep link URL handling (`airwallexcheckout://` scheme)
- [ ] Verify Apple Pay sheet presentation still works
- [ ] Run existing UI tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)