### PR TITLE
[APAM-677] Chain repo dispatch after cocoapods push

### DIFF
--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -24,7 +24,6 @@ jobs:
 
   repo-dispatch:
     needs: cocoapods
-    if: ${{ github.event_name == 'release' && !github.event.release.prerelease }}
     uses: ./.github/workflows/repo-dispatch-on-release.yml
     with:
       tag: ${{ github.event.release.tag_name }}

--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Checkout project
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # 3.6.0
-        
+
       - name: Deploy to CocoaPods
         run: |
           set -eo pipefail
@@ -21,3 +21,11 @@ jobs:
           pod trunk push --allow-warnings
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+
+  repo-dispatch:
+    needs: cocoapods
+    if: ${{ github.event_name == 'release' && !github.event.release.prerelease }}
+    uses: ./.github/workflows/repo-dispatch-on-release.yml
+    with:
+      tag: ${{ github.event.release.tag_name }}
+    secrets: inherit

--- a/.github/workflows/repo-dispatch-on-release.yml
+++ b/.github/workflows/repo-dispatch-on-release.yml
@@ -1,8 +1,12 @@
 name: Repo Dispatch on iOS Release
 
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      tag:
+        description: 'iOS SDK version (e.g., 6.3.0)'
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       tag:
@@ -13,22 +17,13 @@ on:
 jobs:
   repo-dispatch-on-release:
     runs-on: ubuntu-latest
-    # Only trigger for non-prerelease versions (skip for workflow_dispatch)
-    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
     steps:
-      - name: Set version
-        id: version
+      - name: Log version
+        run: 'echo "Dispatching for version: ${{ inputs.tag }}"'
+      - name: Wait for CocoaPods CDN propagation
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ inputs.tag }}"
-            ACTION="manual"
-          else
-            VERSION="${{ github.event.release.tag_name }}"
-            ACTION="${{ github.event.action }}"
-          fi
-          echo "tag=$VERSION" >> $GITHUB_OUTPUT
-          echo "action=$ACTION" >> $GITHUB_OUTPUT
-          echo "Dispatching for version: $VERSION (action: $ACTION)"
+          echo "Waiting 20 minutes for CocoaPods CDN to propagate..."
+          sleep 1200
       - name: Send repository dispatch to Flutter SDK
         env:
           GH_TOKEN: ${{ secrets.SERVICE_ACCOUNT_PAT }}
@@ -36,8 +31,7 @@ jobs:
           gh api repos/airwallex/airwallex-payment-flutter/dispatches \
             --method POST \
             --field event_type='ios_release' \
-            --field client_payload[tag]='${{ steps.version.outputs.tag }}' \
-            --field client_payload[action]='${{ steps.version.outputs.action }}'
+            --field client_payload[tag]='${{ inputs.tag }}'
 
       - name: Send repository dispatch to React Native SDK
         env:
@@ -46,5 +40,4 @@ jobs:
           gh api repos/airwallex/airwallex-payment-react-native/dispatches \
             --method POST \
             --field event_type='ios_release' \
-            --field client_payload[tag]='${{ steps.version.outputs.tag }}' \
-            --field client_payload[action]='${{ steps.version.outputs.action }}'
+            --field client_payload[tag]='${{ inputs.tag }}'

--- a/Airwallex.docc/Airwallex.md
+++ b/Airwallex.docc/Airwallex.md
@@ -5,7 +5,7 @@ The Airwallex iOS SDK is a flexible tool that enables you to integrate payment m
 
 - [Installation](https://github.com/airwallex/airwallex-payment-ios?tab=readme-ov-file#installation)
 - [Required Setup](https://github.com/airwallex/airwallex-payment-ios?tab=readme-ov-file#required-setup)
-- [UI Integration - Hosted Payment Page](https://github.com/airwallex/airwallex-payment-ios?tab=readme-ov-file#ui-integration---hpp-hosted-payment-page)
+- [UI Integration - Hosted Payment Page](https://github.com/airwallex/airwallex-payment-ios?tab=readme-ov-file#ui-integration---hosted-payment-page-hpp)
 - [UI Integration - Embedded Element](https://github.com/airwallex/airwallex-payment-ios?tab=readme-ov-file#ui-integration---embedded)
 - [API Integration](https://github.com/airwallex/airwallex-payment-ios?tab=readme-ov-file#low-level-api-integration)
 


### PR DESCRIPTION
## Summary
- Repo dispatch workflow now runs as a reusable workflow called by `cocoapods.yml` after a successful pod push, instead of triggering independently on release events
- Adds a 20-minute CDN propagation delay before dispatching to downstream repos (Flutter, React Native)
- Prevents downstream CI failures caused by `pod install` running before the new pod version is available on the CDN

## Test plan
- [ ] Create a release and verify cocoapods job runs first, then repo-dispatch fires after the 20-minute delay
- [ ] Verify manual `workflow_dispatch` on `cocoapods.yml` does not trigger repo-dispatch
- [ ] Verify manual `workflow_dispatch` on `repo-dispatch-on-release.yml` still works independently
- [ ] Verify downstream repos receive the correct `tag` in `client_payload`

🤖 Generated with [Claude Code](https://claude.com/claude-code)