### PR TITLE
[APAM-677] Fix wait condition for CDN propagation delay

### DIFF
--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -27,4 +27,5 @@ jobs:
     uses: ./.github/workflows/repo-dispatch-on-release.yml
     with:
       tag: ${{ github.event.release.tag_name }}
+      wait_minutes: 20
     secrets: inherit

--- a/.github/workflows/repo-dispatch-on-release.yml
+++ b/.github/workflows/repo-dispatch-on-release.yml
@@ -7,12 +7,22 @@ on:
         description: 'iOS SDK version (e.g., 6.3.0)'
         required: true
         type: string
+      wait_minutes:
+        description: 'Minutes to wait before dispatching (0 to skip)'
+        required: false
+        type: number
+        default: 0
   workflow_dispatch:
     inputs:
       tag:
         description: 'iOS SDK version (e.g., 6.3.0)'
         required: true
         type: string
+      wait_minutes:
+        description: 'Minutes to wait before dispatching (0 to skip)'
+        required: false
+        type: number
+        default: 0
 
 jobs:
   repo-dispatch-on-release:
@@ -21,10 +31,8 @@ jobs:
       - name: Log version
         run: 'echo "Dispatching for version: ${{ inputs.tag }}"'
       - name: Wait for CocoaPods CDN propagation
-        if: ${{ github.event_name == 'workflow_call' }}
-        run: |
-          echo "Waiting 20 minutes for CocoaPods CDN to propagate..."
-          sleep 1200
+        if: inputs.wait_minutes > 0
+        run: sleep ${{ fromJSON(inputs.wait_minutes) * 60 }}
       - name: Send repository dispatch to Flutter SDK
         env:
           GH_TOKEN: ${{ secrets.SERVICE_ACCOUNT_PAT }}

--- a/.github/workflows/repo-dispatch-on-release.yml
+++ b/.github/workflows/repo-dispatch-on-release.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Log version
         run: 'echo "Dispatching for version: ${{ inputs.tag }}"'
       - name: Wait for CocoaPods CDN propagation
+        if: ${{ github.event_name == 'workflow_call' }}
         run: |
           echo "Waiting 20 minutes for CocoaPods CDN to propagate..."
           sleep 1200


### PR DESCRIPTION
## Summary
- Replace the broken `github.event_name == 'workflow_call'` condition with an explicit `wait_minutes` input
- The previous condition never evaluated to true because `github.event_name` in a reusable workflow reflects the caller's triggering event, not `'workflow_call'`
- `repo-dispatch-on-release.yml` now accepts a `wait_minutes` input (default: 0) from both `workflow_call` and `workflow_dispatch` triggers
- `cocoapods.yml` passes `wait_minutes: 20` so the 20-minute CocoaPods CDN delay is applied correctly after a pod push

## Test plan
- [ ] Verify manual `workflow_dispatch` on `repo-dispatch-on-release.yml` dispatches immediately without waiting (default `wait_minutes: 0`)
- [ ] Verify `workflow_call` from `cocoapods.yml` waits 20 minutes before dispatching

🤖 Generated with [Claude Code](https://claude.com/claude-code)