### PR TITLE
[APAM-748] Default billing country to session country code

### DIFF
--- a/Airwallex/AirwallexPaymentSheet/Sources/PaymentSheet/PaymentSections/NewCardPaymentSectionController.swift
+++ b/Airwallex/AirwallexPaymentSheet/Sources/PaymentSheet/PaymentSections/NewCardPaymentSectionController.swift
@@ -487,6 +487,7 @@ private extension NewCardPaymentSectionController {
         BillingInfoCellViewModel(
             itemIdentifier: .billingFieldAddress,
             prefilledAddress: session.billing?.address,
+            defaultCountryCode: session.countryCode,
             reusePrefilledAddress: reuseShippingAddress,
             countrySelectionHandler: { [weak self] in
                 self?.triggerCountrySelection()
@@ -587,6 +588,8 @@ private extension NewCardPaymentSectionController {
             var country: AWXCountry?
             if let countryCode = session.billing?.address?.countryCode {
                 country = AWXCountry(code: countryCode)
+            } else {
+                country = AWXCountry(code: session.countryCode)
             }
             viewModelForCountryCode = CountrySelectionCellViewModel(
                 country: country,

--- a/Airwallex/AirwallexPaymentSheet/Sources/PaymentSheet/View/ViewModel/BillingInfoCellViewModel.swift
+++ b/Airwallex/AirwallexPaymentSheet/Sources/PaymentSheet/View/ViewModel/BillingInfoCellViewModel.swift
@@ -49,6 +49,7 @@ class BillingInfoCellViewModel: CellViewModelIdentifiable {
     
     init(itemIdentifier: String,
          prefilledAddress: AWXAddress?,
+         defaultCountryCode: String? = nil,
          reusePrefilledAddress: Bool = true,
          countrySelectionHandler: @escaping () -> Void,
          toggleReuseSelection: @escaping () -> Void,
@@ -57,6 +58,8 @@ class BillingInfoCellViewModel: CellViewModelIdentifiable {
         var country: AWXCountry?
         if let countryCode = prefilledAddress?.countryCode {
             country = AWXCountry(code: countryCode)
+        } else if let defaultCountryCode {
+            country = AWXCountry(code: defaultCountryCode)
         }
         
         canReusePrefilledAddress = prefilledAddress?.isComplete ?? false

--- a/Airwallex/AirwallexPaymentSheetTests/PaymentSheetTests/ViewModelTests/BillingInfoCellViewModelTests.swift
+++ b/Airwallex/AirwallexPaymentSheetTests/PaymentSheetTests/ViewModelTests/BillingInfoCellViewModelTests.swift
@@ -6,10 +6,10 @@
 //  Copyright © 2025 Airwallex. All rights reserved.
 //
 
+import AirwallexCore
+@testable import AirwallexPaymentSheet
 import UIKit
 import XCTest
-@testable import AirwallexPaymentSheet
-import AirwallexCore
 
 class BillingInfoCellViewModelTests: XCTestCase {
     
@@ -33,7 +33,7 @@ class BillingInfoCellViewModelTests: XCTestCase {
             reusePrefilledAddress: true,
             countrySelectionHandler: {},
             toggleReuseSelection: {},
-            cellReconfigureHandler: {_,_ in}
+            cellReconfigureHandler: { _, _ in }
         )
         XCTAssertEqual(viewModel.itemIdentifier, mockIdentifier)
         XCTAssertEqual(viewModel.canReusePrefilledAddress, true)
@@ -51,7 +51,7 @@ class BillingInfoCellViewModelTests: XCTestCase {
             reusePrefilledAddress: false,
             countrySelectionHandler: {},
             toggleReuseSelection: {},
-            cellReconfigureHandler: {_,_ in}
+            cellReconfigureHandler: { _, _ in }
         )
         XCTAssertEqual(viewModel.itemIdentifier, mockIdentifier)
         XCTAssertEqual(viewModel.canReusePrefilledAddress, true)
@@ -71,7 +71,7 @@ class BillingInfoCellViewModelTests: XCTestCase {
             reusePrefilledAddress: true,
             countrySelectionHandler: {},
             toggleReuseSelection: {},
-            cellReconfigureHandler: {_,_ in}
+            cellReconfigureHandler: { _, _ in }
         )
         XCTAssertEqual(viewModel.itemIdentifier, mockIdentifier)
         XCTAssertEqual(viewModel.canReusePrefilledAddress, false)
@@ -89,7 +89,7 @@ class BillingInfoCellViewModelTests: XCTestCase {
             reusePrefilledAddress: false,
             countrySelectionHandler: {},
             toggleReuseSelection: {},
-            cellReconfigureHandler: {_,_ in}
+            cellReconfigureHandler: { _, _ in }
         )
         XCTAssertEqual(viewModel.itemIdentifier, mockIdentifier)
         XCTAssertEqual(viewModel.canReusePrefilledAddress, false)
@@ -102,6 +102,48 @@ class BillingInfoCellViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.errorHintForBillingFields)
     }
     
+    func testInit_WithDefaultCountryCode() {
+        let viewModel = BillingInfoCellViewModel(
+            itemIdentifier: mockIdentifier,
+            prefilledAddress: nil,
+            defaultCountryCode: "US",
+            reusePrefilledAddress: false,
+            countrySelectionHandler: {},
+            toggleReuseSelection: {},
+            cellReconfigureHandler: { _, _ in }
+        )
+        XCTAssertEqual(viewModel.itemIdentifier, mockIdentifier)
+        XCTAssertEqual(viewModel.canReusePrefilledAddress, false)
+        XCTAssertEqual(viewModel.shouldReusePrefilledAddress, false)
+        XCTAssertEqual(viewModel.countryConfigurer.country?.countryCode, "US")
+        XCTAssertNil(viewModel.stateConfigurer.text)
+        XCTAssertNil(viewModel.cityConfigurer.text)
+        XCTAssertNil(viewModel.streetConfigurer.text)
+        XCTAssertNil(viewModel.zipConfigurer.text)
+        XCTAssertNil(viewModel.errorHintForBillingFields)
+    }
+
+    func testInit_DefaultCountryCode_OverriddenByAddress() {
+        let viewModel = BillingInfoCellViewModel(
+            itemIdentifier: mockIdentifier,
+            prefilledAddress: mockAddress,
+            defaultCountryCode: "US",
+            reusePrefilledAddress: true,
+            countrySelectionHandler: {},
+            toggleReuseSelection: {},
+            cellReconfigureHandler: { _, _ in }
+        )
+        XCTAssertEqual(viewModel.itemIdentifier, mockIdentifier)
+        XCTAssertEqual(viewModel.canReusePrefilledAddress, true)
+        XCTAssertEqual(viewModel.shouldReusePrefilledAddress, true)
+        XCTAssertEqual(viewModel.countryConfigurer.country?.countryCode, "AU")
+        XCTAssertEqual(viewModel.stateConfigurer.text, mockAddress.state)
+        XCTAssertEqual(viewModel.cityConfigurer.text, mockAddress.city)
+        XCTAssertEqual(viewModel.streetConfigurer.text, mockAddress.street)
+        XCTAssertEqual(viewModel.zipConfigurer.text, mockAddress.postcode)
+        XCTAssertNil(viewModel.errorHintForBillingFields)
+    }
+
     func testInit_IncompleteAddress() {
         mockAddress.countryCode = nil
         var viewModel = BillingInfoCellViewModel(
@@ -110,7 +152,7 @@ class BillingInfoCellViewModelTests: XCTestCase {
             reusePrefilledAddress: true,
             countrySelectionHandler: {},
             toggleReuseSelection: {},
-            cellReconfigureHandler: {_,_ in}
+            cellReconfigureHandler: { _, _ in }
         )
         XCTAssertEqual(viewModel.itemIdentifier, mockIdentifier)
         XCTAssertEqual(viewModel.canReusePrefilledAddress, false)
@@ -128,7 +170,7 @@ class BillingInfoCellViewModelTests: XCTestCase {
             reusePrefilledAddress: false,
             countrySelectionHandler: {},
             toggleReuseSelection: {},
-            cellReconfigureHandler: {_,_ in}
+            cellReconfigureHandler: { _, _ in }
         )
         XCTAssertEqual(viewModel.itemIdentifier, mockIdentifier)
         XCTAssertEqual(viewModel.canReusePrefilledAddress, false)
@@ -148,7 +190,7 @@ class BillingInfoCellViewModelTests: XCTestCase {
             reusePrefilledAddress: true,
             countrySelectionHandler: {},
             toggleReuseSelection: {},
-            cellReconfigureHandler: {_,_ in}
+            cellReconfigureHandler: { _, _ in }
         )
         
         let address = viewModel.billingAddressFromCollectedInfo()
@@ -168,7 +210,7 @@ class BillingInfoCellViewModelTests: XCTestCase {
             reusePrefilledAddress: true,
             countrySelectionHandler: {},
             toggleReuseSelection: {},
-            cellReconfigureHandler: {_,_ in}
+            cellReconfigureHandler: { _, _ in }
         )
         viewModel.updateValidStatusForCheckout()
         XCTAssertFalse(viewModel.countryConfigurer.isValid)
@@ -200,7 +242,7 @@ class BillingInfoCellViewModelTests: XCTestCase {
             reusePrefilledAddress: true,
             countrySelectionHandler: {},
             toggleReuseSelection: {},
-            cellReconfigureHandler: {_,_ in}
+            cellReconfigureHandler: { _, _ in }
         )
         XCTAssertNoThrow(try viewModel.validate())
         

--- a/Examples/Examples/Controllers/DemoDataSource.swift
+++ b/Examples/Examples/Controllers/DemoDataSource.swift
@@ -108,7 +108,7 @@ struct DemoDataSource {
                 "country_code": "US",
                 "state": "CA",
                 "city": "San Francisco",
-                "street": "1460 Mission St.#02W101",
+                "street": "9999 Mission St.",
                 "postcode": "94103"
             ]
         ]


### PR DESCRIPTION
## Summary
- Default the billing country selector to the session's `countryCode` when no billing address country is pre-filled
- Replace real-world street address in the sample app with a fictitious one (`9999 Mission St.`)
- Add unit tests covering the new `defaultCountryCode` fallback behaviour in `BillingInfoCellViewModel`

## Test plan
- [ ] `BillingInfoCellViewModelTests` — `testInit_WithDefaultCountryCode` and `testInit_DefaultCountryCode_OverriddenByAddress` pass
- [ ] Card payment sheet with no billing address pre-filled shows the session country pre-selected in the country field
- [ ] Card payment sheet with a billing address pre-filled continues to show the address's country (not overridden by session country)

🤖 Generated with [Claude Code](https://claude.com/claude-code)