### PR TITLE
[APAM-792] fix layout issue caused by intrinsic content size of ContentInsetableTextField

### DIFF
--- a/Airwallex/AirwallexPaymentSheet/Sources/PaymentSheet/View/InputFields/ContentInsetableTextField.swift
+++ b/Airwallex/AirwallexPaymentSheet/Sources/PaymentSheet/View/InputFields/ContentInsetableTextField.swift
@@ -12,17 +12,34 @@ class ContentInsetableTextField: UITextField {
     
     var textInsets: UIEdgeInsets {
         didSet {
+            invalidateIntrinsicContentSize()
             setNeedsLayout()
         }
     }
-    
+
     init(textInsets: UIEdgeInsets = .zero) {
         self.textInsets = textInsets
         super.init(frame: .zero)
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    override var font: UIFont? {
+        didSet { invalidateIntrinsicContentSize() }
+    }
+
+    // UITextField falls back to the system font when both `text` and
+    // `attributedPlaceholder` are empty, producing a slightly taller intrinsic
+    // height than when content is present. Compute it from the configured font
+    // and insets so the height stays stable regardless of content.
+    override var intrinsicContentSize: CGSize {
+        let lineHeight = (font ?? .systemFont(ofSize: UIFont.systemFontSize)).lineHeight
+        return CGSize(
+            width: UIView.noIntrinsicMetric,
+            height: ceil(lineHeight) + textInsets.top + textInsets.bottom
+        )
     }
     
     // Rect for text already in the field


### PR DESCRIPTION
When a `UITextField` has no `text`, its `intrinsicContentSize` is calculated using the system default font instead of the assigned font, such as `.awxFont(.body2)`. As a result, the field’s height can change when the user starts and stops typing, causing a visual glitch.

This PR gives `ContentInsetableTextField` a deterministic height to prevent that behavior.

Before:

https://github.com/user-attachments/assets/4f427692-c303-4d66-b799-152750a6daf0

After: 

https://github.com/user-attachments/assets/d1aa5fd8-0731-40a1-a420-7fa3b65ab2e1
