### PR TITLE
[APAM-875] Add SDK language setting to Examples app

### DIFF
--- a/Airwallex/AirwallexCore/Sources/Model/AWXSession.m
+++ b/Airwallex/AirwallexCore/Sources/Model/AWXSession.m
@@ -21,7 +21,6 @@
 - (instancetype)init {
     if (self = [super init]) {
         self.requiredBillingContactFields = AWXRequiredBillingContactFieldName;
-        self.lang = [NSBundle preferredLocalizationsFromArray:NSBundle.resourceBundle.localizations forPreferences:NSBundle.mainBundle.preferredLocalizations].firstObject ?: @"en";
     }
 
     return self;

--- a/Airwallex/AirwallexPayment/Sources/Extensions/AWXSession+Extensions.swift
+++ b/Airwallex/AirwallexPayment/Sources/Extensions/AWXSession+Extensions.swift
@@ -15,16 +15,17 @@ private let localizationComment = "session validation"
 
 package func resolvePaymentLanguage(_ lang: String?) -> AWXPaymentLanguage {
     let trimmedLanguage = lang?.trimmingCharacters(in: .whitespacesAndNewlines)
-    let preferences: [String]
+
+    var preferences = Bundle.main.preferredLocalizations
     if let trimmedLanguage, !trimmedLanguage.isEmpty {
-        preferences = [trimmedLanguage]
-    } else {
-        preferences = Bundle.main.preferredLocalizations
+        preferences.insert(trimmedLanguage, at: 0)
     }
+
     let localization = Bundle.preferredLocalizations(
         from: Bundle.payment.localizations,
         forPreferences: preferences
     ).first
+
     return localization.flatMap(AWXPaymentLanguage.init(rawValue:)) ?? .english
 }
 

--- a/Airwallex/AirwallexPayment/Sources/Models/Session.swift
+++ b/Airwallex/AirwallexPayment/Sources/Models/Session.swift
@@ -67,7 +67,6 @@ import Foundation
     ///                         - false: Show saved payment methods (if available)
     ///                         Default: false.
     ///   - lang: Preferred BCP-47 language identifier for SDK UI.
-    ///           Nil preserves the default initialized by `AWXSession`.
     ///   - paymentMethods: Array of payment method identifiers to limit which methods are displayed.
     ///                    Useful for restricting to specific payment types (e.g., ["card", "wechatpay"]).
     ///                    If nil, all available methods for the region are shown. Default: nil.
@@ -100,9 +99,7 @@ import Foundation
         self.autoCapture = autoCapture
         self.autoSaveCardForFuturePayments = autoSaveCardForFuturePayments
         super.init()
-        if let lang {
-            self.lang = lang
-        }
+        self.lang = lang
         self.countryCode = countryCode
         self.hidePaymentConsents = hidePaymentConsents
         self.returnURL = returnURL
@@ -128,7 +125,6 @@ import Foundation
     ///   - billing: Pre-filled billing address information. Default: nil.
     ///   - hidePaymentConsents: Whether to hide previously saved payment methods. Default: false.
     ///   - lang: Preferred BCP-47 language identifier for SDK UI.
-    ///           Nil preserves the default initialized by `AWXSession`.
     ///   - paymentMethods: Array of payment method identifiers to limit display. Default: nil.
     ///   - paymentConsentOptions: Configuration for recurring payments. Default: nil.
     ///   - requiredBillingContactFields: Which billing contact fields are mandatory. Default: .name.
@@ -152,9 +148,7 @@ import Foundation
         self.autoCapture = autoCapture
         self.autoSaveCardForFuturePayments = autoSaveCardForFuturePayments
         super.init()
-        if let lang {
-            self.lang = lang
-        }
+        self.lang = lang
         self.countryCode = countryCode
         self.hidePaymentConsents = hidePaymentConsents
         self.returnURL = returnURL

--- a/Airwallex/AirwallexPaymentTests/Models/SessionTests.swift
+++ b/Airwallex/AirwallexPaymentTests/Models/SessionTests.swift
@@ -60,7 +60,7 @@ final class SessionTests: XCTestCase {
         XCTAssertEqual(session.countryCode, mockCountryCode)
         XCTAssertEqual(session.returnURL, mockReturnURL)
         XCTAssertFalse(session.hidePaymentConsents)
-        XCTAssertEqual(session.lang, defaultCoreLanguage)
+        XCTAssertNil(session.lang)
         XCTAssertEqual(session.requiredBillingContactFields, .name)
         XCTAssertNil(session.billing)
         XCTAssertNil(session.applePayOptions)
@@ -104,16 +104,6 @@ final class SessionTests: XCTestCase {
         XCTAssertEqual(session.applePayOptions, applePayOptions)
         XCTAssertEqual(session.paymentMethods, mockPaymentMethods)
     }
-
-    func testInit_withNilLangPreservesCoreDefault() {
-        let session = Session(
-            paymentIntent: mockPaymentIntent,
-            countryCode: mockCountryCode,
-            lang: nil
-        )
-
-        XCTAssertEqual(session.lang, defaultCoreLanguage)
-    }
     
     // MARK: - PaymentIntentProvider Initialization Tests
 
@@ -140,7 +130,7 @@ final class SessionTests: XCTestCase {
         XCTAssertEqual(session.countryCode, mockCountryCode)
         XCTAssertEqual(session.returnURL, mockReturnURL)
         XCTAssertFalse(session.hidePaymentConsents)
-        XCTAssertEqual(session.lang, defaultCoreLanguage)
+        XCTAssertNil(session.lang)
         XCTAssertEqual(session.requiredBillingContactFields, .name)
         XCTAssertNil(session.billing)
         XCTAssertNil(session.applePayOptions)

--- a/Examples/Examples/Controllers/GetPaymentMethodsViewController.swift
+++ b/Examples/Examples/Controllers/GetPaymentMethodsViewController.swift
@@ -146,6 +146,7 @@ class GetPaymentMethodsViewController: UITableViewController {
         request.pageNum = 0
         request.pageSize = 1000
         request.flow = AWXPaymentMethodFlow.app.rawValue
+        request.lang = ExamplesKeys.sdkLang
         return try await awxClient.send(request) as! AWXGetPaymentMethodTypesResponse
     }
     

--- a/Examples/Examples/Controllers/IntegrationDemoListViewController.swift
+++ b/Examples/Examples/Controllers/IntegrationDemoListViewController.swift
@@ -217,6 +217,7 @@ extension IntegrationDemoListViewController {
             applePayOptions: DemoDataSource.applePayOptions,
             autoCapture: ExamplesKeys.autoCapture,
             billing: shippingAddress,
+            lang: ExamplesKeys.sdkLang,
             paymentConsentOptions: consentOptions,
             requiredBillingContactFields: getRequiredBillingContactFields(),
             returnURL: ExamplesKeys.returnUrl
@@ -232,7 +233,7 @@ extension IntegrationDemoListViewController {
             applePayOptions: DemoDataSource.applePayOptions,
             autoCapture: ExamplesKeys.autoCapture,
             billing: shippingAddress,
-//            lang: "zh-HK", // use BCP-47 identifier to enforce a language
+            lang: ExamplesKeys.sdkLang,
             paymentConsentOptions: consentOptions,
             requiredBillingContactFields: getRequiredBillingContactFields(),
             returnURL: ExamplesKeys.returnUrl
@@ -301,6 +302,8 @@ extension IntegrationDemoListViewController {
         paymentSession.returnURL = ExamplesKeys.returnUrl
         // update required billing contact fields
         paymentSession.requiredBillingContactFields = getRequiredBillingContactFields()
+        // Preferred BCP-47 language identifier for SDK UI.
+        paymentSession.lang = ExamplesKeys.sdkLang
         return paymentSession
     }
     

--- a/Examples/Examples/Controllers/IntegrationDemoListViewController.swift
+++ b/Examples/Examples/Controllers/IntegrationDemoListViewController.swift
@@ -232,7 +232,7 @@ extension IntegrationDemoListViewController {
             applePayOptions: DemoDataSource.applePayOptions,
             autoCapture: ExamplesKeys.autoCapture,
             billing: shippingAddress,
-//            lang: "fr", // use BCP-47 identifier to enforce a language
+//            lang: "zh-HK", // use BCP-47 identifier to enforce a language
             paymentConsentOptions: consentOptions,
             requiredBillingContactFields: getRequiredBillingContactFields(),
             returnURL: ExamplesKeys.returnUrl

--- a/Examples/Examples/Controllers/SettingsViewController.swift
+++ b/Examples/Examples/Controllers/SettingsViewController.swift
@@ -76,6 +76,13 @@ class SettingsViewController: UIViewController {
         view.accessibilityIdentifier = AccessibilityIdentifiers.SettingsScreen.optionButtonForLayout
         return view
     }()
+
+    private lazy var optionForLanguage: ConfigActionView = {
+        let view = ConfigActionView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.accessibilityIdentifier = AccessibilityIdentifiers.SettingsScreen.optionButtonForLanguage
+        return view
+    }()
     
     private lazy var switchForForce3DS: ConfigSwitchView = {
         let view = ConfigSwitchView()
@@ -267,7 +274,8 @@ private extension SettingsViewController {
         stack.addArrangedSubview(fieldForCurrency)
         stack.addArrangedSubview(fieldForCountryCode)
         stack.addArrangedSubview(fieldForReturnURL)
-        
+        stack.addArrangedSubview(optionForLanguage)
+
         stack.addArrangedSubview(regionLabel)
         stack.addArrangedSubview(versionLabel)
         
@@ -305,6 +313,7 @@ private extension SettingsViewController {
         setupOptionForEnvironment()
         setupOptionForNextTrigger()
         setupOptionForPaymentLayout()
+        setupOptionForLanguage()
         setupSwitches()
         setupCustomerIDGenerator()
         setupFields()
@@ -393,6 +402,31 @@ private extension SettingsViewController {
             }
         )
         optionForPaymentLayout.setup(viewModel)
+    }
+
+    func setupOptionForLanguage() {
+        let options = ExamplesKeys.sdkLanguageOptions + ["Default"]
+        let configValue = settings.sdkLang ?? "Default"
+
+        let viewModel = ConfigActionViewModel(
+            configName: "Language",
+            configValue: configValue,
+            primaryAction: { [weak self] optionView in
+                guard let self else { return }
+                self.showOptions(options, sender: optionView) { index, _ in
+                    let newValue: String?
+                    if index < ExamplesKeys.sdkLanguageOptions.count {
+                        newValue = ExamplesKeys.sdkLanguageOptions[index]
+                    } else {
+                        newValue = nil
+                    }
+                    guard self.settings.sdkLang != newValue else { return }
+                    self.settings.sdkLang = newValue
+                    self.setupOptionForLanguage()
+                }
+            }
+        )
+        optionForLanguage.setup(viewModel)
     }
     
     func setupSwitches() {

--- a/Examples/Examples/ExamplesKeys.swift
+++ b/Examples/Examples/ExamplesKeys.swift
@@ -72,6 +72,13 @@ struct ExamplesKeys {
     @Storage("expressCheckout", defaultValue: true)
     static var expressCheckout: Bool
 
+    @OptionalStorage("airwallex_sdk_lang")
+    static var sdkLang: String?
+
+    static let sdkLanguageOptions: [String] = [
+        "de", "en", "es", "fr", "ja", "ko", "pt-BR", "pt-PT", "ru", "th", "zh-Hans", "zh-Hant"
+    ]
+
     static var allSettings: AllSettings {
         get {
             AllSettings(
@@ -93,7 +100,8 @@ struct ExamplesKeys {
                 returnUrl: ExamplesKeys.returnUrl,
                 paymentLayout: ExamplesKeys.paymentLayout,
                 preferUnifiedSession: ExamplesKeys.preferUnifiedSession,
-                expressCheckout: ExamplesKeys.expressCheckout
+                expressCheckout: ExamplesKeys.expressCheckout,
+                sdkLang: ExamplesKeys.sdkLang
             )
         }
         set {
@@ -117,6 +125,7 @@ struct ExamplesKeys {
             ExamplesKeys.paymentLayout = newValue.paymentLayout
             ExamplesKeys.preferUnifiedSession = newValue.preferUnifiedSession
             ExamplesKeys.expressCheckout = newValue.expressCheckout
+            ExamplesKeys.sdkLang = newValue.sdkLang
         }
     }
     
@@ -142,7 +151,8 @@ struct ExamplesKeys {
         var paymentLayout: AWXUIContext.PaymentLayout
         var preferUnifiedSession: Bool
         var expressCheckout: Bool
-        
+        var sdkLang: String?
+
         init(environment: AirwallexSDKMode,
              nextTriggerByType: AirwallexNextTriggerByType,
              requiresName: Bool,
@@ -161,7 +171,8 @@ struct ExamplesKeys {
              returnUrl: String,
              paymentLayout: AWXUIContext.PaymentLayout,
              preferUnifiedSession: Bool,
-             expressCheckout: Bool) {
+             expressCheckout: Bool,
+             sdkLang: String? = nil) {
             self.environment = environment
             self.nextTriggerByType = nextTriggerByType
             self.requiresName = requiresName
@@ -181,6 +192,7 @@ struct ExamplesKeys {
             self.paymentLayout = paymentLayout
             self.preferUnifiedSession = preferUnifiedSession
             self.expressCheckout = expressCheckout
+            self.sdkLang = sdkLang
         }
         
         var description: String {
@@ -204,6 +216,7 @@ struct ExamplesKeys {
                 ├── Payment Layout: \(paymentLayout)
                 ├── Prefer Unified Session: \(preferUnifiedSession)
                 ├── Express Checkout: \(expressCheckout)
+                ├── SDK Language: \(sdkLang ?? "Default")
                 """
         }
     }

--- a/Examples/Examples/Util/AccessibilityIdentifiers.swift
+++ b/Examples/Examples/Util/AccessibilityIdentifiers.swift
@@ -14,6 +14,7 @@ enum AccessibilityIdentifiers {
         static let optionButtonForEnvironment = "optionButtonForEnvironment"
         static let optionButtonForNextTriggerBy = "optionButtonForNextTriggerBy"
         static let optionButtonForLayout = "optionButtonForLayout"
+        static let optionButtonForLanguage = "optionButtonForLanguage"
         static let textFieldForCustomerID = "textFieldForCustomerID"
         static let actionButtonForCustomerID = "actionButtonForCustomerID"
         static let toggleFor3DS = "toggleFor3DS"


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/0779157d-d0d6-41e5-8aa7-fdc9aa3f0747


- Clarify `AWXSession.lang` semantics: unset stays `nil`, and `resolvePaymentLanguage` falls back through host app preferred localizations before SDK-supported locales.
- Add a persisted **Language** setting in the Examples app so developers can pick an Airwallex SDK UI language (BCP-47 tags aligned with `AWXPaymentLanguage`) or **Default** (`nil`).
- Apply `ExamplesKeys.sdkLang` when creating payment sessions (unified `Session` and legacy subclasses) and when fetching payment method types.

## Test plan
- [x] Open Examples → Settings → Language defaults to **Default**
- [x] Select a language tag (e.g. `fr`), Save, relaunch → selection persists
- [x] Start UI / API / Embedded demos → payment UI uses selected language; `session.lang` matches setting
- [x] Select **Default** → `session.lang` is `nil`; UI follows host app locale resolution
- [x] Reset settings → language returns to **Default**
- [x] Get Payment Methods demo sends `lang` from settings on the API request


Made with [Cursor](https://cursor.com)