### PR TITLE
[APAM-889] Size payment method tab cells for multi-line labels

### DIFF
--- a/Airwallex/AirwallexPaymentSheet/Sources/PaymentSheet/PaymentSections/PaymentMethodTabSectionController.swift
+++ b/Airwallex/AirwallexPaymentSheet/Sources/PaymentSheet/PaymentSections/PaymentMethodTabSectionController.swift
@@ -77,12 +77,19 @@ class PaymentMethodTabSectionController: SectionController {
     }
     
     func layout(environment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection {
+        // TODO: When the minimum deployment target is iOS 17+, update layout to use `.uniformAcrossSiblings(estimate:)` as height dimension so sibling items share a uniform height.
+        let itemHeight = PaymentMethodCell.estimatedItemHeight(
+            displayNames: methodTypes.map(\.displayName)
+        )
         let layoutSize = NSCollectionLayoutSize(
-            widthDimension: .absolute(92),
-            heightDimension: .absolute(70)
+            widthDimension: .absolute(PaymentMethodCell.itemWidth),
+            heightDimension: .absolute(itemHeight)
         )
         let item = NSCollectionLayoutItem(layoutSize: layoutSize)
-        let group = NSCollectionLayoutGroup.vertical(layoutSize: layoutSize, subitems: [item])
+        let group = NSCollectionLayoutGroup.horizontal(
+            layoutSize: layoutSize,
+            subitems: [item]
+        )
         let section = NSCollectionLayoutSection(group: group)
         section.orthogonalScrollingBehavior = .continuous
         section.contentInsets = .init(horizontal: paymentUIContext.isEmbedded ? 0 : 16).bottom(8)

--- a/Airwallex/AirwallexPaymentSheet/Sources/PaymentSheet/View/PaymentMethodCell.swift
+++ b/Airwallex/AirwallexPaymentSheet/Sources/PaymentSheet/View/PaymentMethodCell.swift
@@ -35,7 +35,19 @@ struct PaymentMethodCellViewModel: CellViewModelIdentifiable, CardBrandViewConfi
 }
 
 class PaymentMethodCell: UICollectionViewCell, ViewReusable, ViewConfigurable {
-    
+
+    private enum Layout {
+        static let itemWidth: CGFloat = 92
+        static let horizontalPadding: CGFloat = 16
+        static let topPadding: CGFloat = 16
+        static let bottomPadding: CGFloat = 8
+        static let verticalPadding: CGFloat = topPadding + bottomPadding
+        static let logoWidth: CGFloat = 30
+        static let logoHeight: CGFloat = 20
+        static let stackSpacing: CGFloat = 8
+        static let maxLabelLines = 2
+    }
+
     private let roundedBG: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
@@ -59,6 +71,8 @@ class PaymentMethodCell: UICollectionViewCell, ViewReusable, ViewConfigurable {
         view.translatesAutoresizingMaskIntoConstraints = false
         view.font = UIFont.awxFont(.caption2)
         view.textColor = .awxColor(.textLink)
+        view.numberOfLines = Layout.maxLabelLines
+        view.textAlignment = .center
         return view
     }()
     
@@ -66,7 +80,7 @@ class PaymentMethodCell: UICollectionViewCell, ViewReusable, ViewConfigurable {
         let view = UIStackView()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.axis = .vertical
-        view.spacing = 8
+        view.spacing = Layout.stackSpacing
         view.alignment = .center
         return view
     }()
@@ -112,13 +126,58 @@ private extension PaymentMethodCell {
         stack.addArrangedSubview(label)
         
         let constraints = [
-            logo.widthAnchor.constraint(equalToConstant: 30),
-            logo.heightAnchor.constraint(equalToConstant: 20),
-            
+            logo.widthAnchor.constraint(equalToConstant: Layout.logoWidth),
+            logo.heightAnchor.constraint(equalToConstant: Layout.logoHeight),
+
             stack.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
-            stack.centerYAnchor.constraint(equalTo: contentView.centerYAnchor, constant: 4),
-            stack.widthAnchor.constraint(lessThanOrEqualTo: contentView.widthAnchor, constant: -16),
+            stack.topAnchor.constraint(equalTo: contentView.topAnchor, constant: Layout.topPadding),
+            stack.widthAnchor.constraint(
+                lessThanOrEqualTo: contentView.widthAnchor,
+                constant: -Layout.horizontalPadding
+            ),
+            stack.heightAnchor.constraint(
+                lessThanOrEqualTo: contentView.heightAnchor,
+                constant: -Layout.verticalPadding
+            )
         ]
         NSLayoutConstraint.activate(constraints)
+    }
+}
+
+extension PaymentMethodCell {
+    static let itemWidth = Layout.itemWidth
+
+    private static let sizingLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = Layout.maxLabelLines
+        label.textAlignment = .center
+        label.font = UIFont.awxFont(.caption2)
+        return label
+    }()
+
+    private static func estimatedLabelHeight(for text: String, width: CGFloat) -> CGFloat {
+        sizingLabel.text = text
+        return sizingLabel.sizeThatFits(
+            CGSize(width: width, height: .greatestFiniteMagnitude)
+        ).height
+    }
+
+    static func estimatedItemHeight(
+        displayNames: [String],
+        itemWidth: CGFloat = Layout.itemWidth
+    ) -> CGFloat {
+        let labelWidth = itemWidth - Layout.horizontalPadding
+        let font = UIFont.awxFont(.caption2)
+        let labelHeight = displayNames
+            .map { estimatedLabelHeight(for: $0, width: labelWidth) }
+            .max() ?? font.lineHeight
+
+        return ceil(
+            Layout.topPadding
+            + Layout.logoHeight
+            + Layout.stackSpacing
+            + labelHeight
+            + Layout.bottomPadding
+        )
     }
 }


### PR DESCRIPTION
## Summary
- Allow payment method tab labels to wrap to two lines with centered text
- Compute tab cell height dynamically from display names using a sizing label so longer names are not clipped
- Centralize layout constants in `PaymentMethodCell` and switch the section to a horizontal group layout

## Test plan
- [ ] Open payment sheet with multiple payment methods and verify tab labels display correctly for short names
- [ ] Test with long or localized payment method names that require two lines
- [ ] Confirm selected tab label is not clipped when bold
- [ ] Verify horizontal scrolling still works in the payment method tab section
- [ ] Smoke test embedded vs full payment sheet layouts


Made with [Cursor](https://cursor.com)